### PR TITLE
Track downloads of Provider Data

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,6 +62,8 @@
     gtag('js', new Date());
 
     gtag('config', '{{site.google_analytics_id}}');
+
+    {{ page.gtags_script }}
   </script>
 </body>
 </html>

--- a/provider-map.html
+++ b/provider-map.html
@@ -1,6 +1,15 @@
 ---
 layout: default
 class_name: provider-map
+gtags_script: |
+  function handleDownloadClick() {
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'Downloads',
+      eventAction: 'download',
+      eventLabel: 'Provider Data Package',
+    });
+  }
 ---
 <script>const data_mapbox = "mapbox";</script>
 <script defer src="https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.js"></script>
@@ -97,6 +106,7 @@ class_name: provider-map
         <a
           class="btn btn-primary provider-data-download-button"
           href="/metadata/providers/package.zip"
+          onclick="handleDownloadClick()"
           target="_self"
         >
           Download data


### PR DESCRIPTION
Technically, this unique enough and small enough that it can just be added to the Default layout. Though, I'm not sure if we'd be finding more things to track and just do things on a per-page basis. At the moment, I'm abusing front matter to place all of our related Google function calls together in a single script tag.

Fixes #273
