### PR TITLE
fix(analytics): use gtag script instead of ga

### DIFF
--- a/provider-map.html
+++ b/provider-map.html
@@ -3,7 +3,7 @@ layout: default
 class_name: provider-map
 gtags_script: |
   function handleDownloadClick() {
-    gtag('event', 'download' {
+    gtag('event', 'download', {
       event_category: 'downloads',
       event_label: 'Provider Data Package',
     });

--- a/provider-map.html
+++ b/provider-map.html
@@ -3,11 +3,9 @@ layout: default
 class_name: provider-map
 gtags_script: |
   function handleDownloadClick() {
-    ga('send', {
-      hitType: 'event',
-      eventCategory: 'Downloads',
-      eventAction: 'download',
-      eventLabel: 'Provider Data Package',
+    gtag('event', 'download' {
+      event_category: 'downloads',
+      event_label: 'Provider Data Package',
     });
   }
 ---


### PR DESCRIPTION
Events were not being registered in Google Analytics, need to use the Universal Analytics syntax:

https://developers.google.com/analytics/devguides/collection/gtagjs/events