### PR TITLE
fix(providers/data): fix Fremont misspelling

### DIFF
--- a/metadata/providers/providers.csv
+++ b/metadata/providers/providers.csv
@@ -130,7 +130,7 @@ Azusa Transit,90250,6,0,35321,0,14875,0,,,Azusa,Los Angeles,,https://www.ci.azus
 Cypress Transportation,,,,,,,,,,Cypress,Orange,,https://www.cypressca.org/government/departments/recreation-community-services/senior-center/transportation,,,,,
 Vacaville City Coach,90155,15,15,15527,405254,31395,344352,,"cash, card, benefit",Vacaville,Solano,,http://www.citycoach.com/,,http://data.trilliumtransit.com/gtfs/vacavillecitycoach-ca-us/vacavillecitycoach-ca-us.zip,,,
 Beverly Hills,90255,4,0,11012,0,0,0,,,Beverly Hills,Los Angeles,,http://www.beverlyhills.org/living/transportation/,,,,,
-"Drivers for Survivors, Inc.",,,,,,,,,,Freemont,Alameda,,https://driversforsurvivors.org/,,,,,
+"Drivers for Survivors, Inc.",,,,,,,,,,Fremont,Alameda,,https://driversforsurvivors.org/,,,,,
 El Segundo Lunchtime Shuttle,,,,,,,,Flat,,El Segundo,Los Angeles,"Metro, Beach Cities Transit",http://www.elsegundo.org/depts/recreation/brochure_and_programs/shuttle_services.asp,https://www.elsegundorecparks.org/programs-services/transportation,,,,
 Norwalk Transit System,90022,29,29,22344,1461068,17337,1219874,Flat,"cash, card",Norwalk,Los Angeles,,https://www.norwalk.org/city-hall/departments/norwalk-transit-system-nts,https://www.norwalk.org/city-hall/departments/norwalk-transit-system-nts/fares-schedules,http://data.trilliumtransit.com/gtfs/nts-ca-us/nts-ca-us.zip,,,
 Catholic Charities of the Diocese of Stockton,,,,,,,,,,Stockton,San Joaquin,,https://www.ccstockton.org/,,,,,


### PR DESCRIPTION
`Fremont` was misspelled.

I noticed the URL for this provider is now a dead link (https://driversforsurvivors.org) and it looks like the service is now ending (https://www.mercurynews.com/2020/11/17/drivers-for-survivors-facing-revenue-loss-amid-pandemic-to-end-program-in-early-2021/) - How to proceed?