### PR TITLE
Feat: add link to existing data plan contracts

### DIFF
--- a/src/_data/contracts.yml
+++ b/src/_data/contracts.yml
@@ -61,3 +61,12 @@ entries:
     product: Payment Acceptance Devices
     user_instructions: ~
     footnotes: ~
+
+  - contract: View Data Plans
+    contract_url: https://cdt.ca.gov/services/calnet-calitp/
+    vendor: Verizon, AT&T, T-Mobile
+    category: Connectivity
+    product: Data Plans
+    user_instructions: ~
+    footnotes:
+      - 1

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -33,6 +33,15 @@ new_technology:
     content: >
       On-board or platform devices equipped with the technology to read and validate riders’ contactless bank
       cards and smart devices.
+
+  - icon: connectivity.svg
+    icon-alt: A signal connection strength indicator
+    title: Data plans
+    url: ./view?contracts-filter-product=Data Plans
+    button: View contracts
+    content: >
+      Fleet modernization and new vehicle technology are allowing us to be even more connected with our transit journeys.
+      To do this, most require data access. These data plans are available to agencies with the pre-negotiated rates listed.
 ---
 
 <p>

--- a/src/uploads/connectivity.svg
+++ b/src/uploads/connectivity.svg
@@ -1,0 +1,7 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="5" y="26.5714" width="5.14286" height="15.4286" rx="0.5" fill="#ED9F2E" stroke="#ED9F2E" stroke-width="0.8"/>
+<rect x="13.2286" y="21.4286" width="5.14286" height="20.5714" rx="0.5" fill="#ED9F2E" stroke="#ED9F2E" stroke-width="0.8"/>
+<rect x="21.4572" y="16.2857" width="5.14286" height="25.7143" rx="0.5" fill="#ED9F2E" stroke="#ED9F2E" stroke-width="0.8"/>
+<rect x="29.6857" y="11.1429" width="5.14286" height="30.8571" rx="0.5" fill="#ED9F2E" stroke="#ED9F2E" stroke-width="0.8"/>
+<rect x="37.9143" y="6" width="5.14286" height="36" rx="0.5" stroke="#ED9F2E"/>
+</svg>


### PR DESCRIPTION
Closes #309

## Notes

* I assumed we wanted a single table row, listing all 3 vendors
* I also assumed we needed to apply the "Only for CA transit agencies" footnote to the table row
* Made the _Contract_ column say "View Data Plans" instead of "View" for clarity