### PR TITLE
chore(gitignore): ignore all .DS_Store files from Mac users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site/
 data/providers/*.json
 node_modules/
 vendor/
+**/.DS_Store


### PR DESCRIPTION
Having `**/.DS_Store` ignored in Git is a standard practice for Apple/Mac users.

I realize @thekaveman @angela-tran won't really be able to test this locally though 😅  It's here in benefits: https://github.com/cal-itp/benefits/blob/dev/.gitignore#L11

Reference:
https://stackoverflow.com/questions/18393498/gitignore-all-the-ds-store-files-in-every-folder-and-subfolder
https://en.wikipedia.org/wiki/.DS_Store

