### PR TITLE
Contracts page: Add blurb

### DIFF
--- a/src/_sass/_base.scss
+++ b/src/_sass/_base.scss
@@ -76,8 +76,8 @@ h4,
   font-size: calc(16rem / 16);
 }
 
-.italics {
-  color: #136c97;
+.subtext {
+  color: $primary-blue;
   font-size: calc(14rem / 16);
   font-weight: 500;
 }

--- a/src/_sass/_base.scss
+++ b/src/_sass/_base.scss
@@ -40,10 +40,23 @@ h1,
 h2,
 h3,
 h4,
+.h4,
 h5,
 h6 {
   font-weight: bold;
+}
+
+h1,
+h2,
+h3 {
   font-family: $headings-font-family;
+}
+
+h4,
+.h4,
+h5,
+h6 {
+  font-family: $font-family-sans-serif;
 }
 
 h1 {
@@ -58,7 +71,8 @@ h3 {
   font-size: calc(24rem / 16);
 }
 
-h4 {
+h4,
+.h4 {
   font-size: calc(16rem / 16);
 }
 

--- a/src/_sass/_base.scss
+++ b/src/_sass/_base.scss
@@ -78,7 +78,7 @@ h4,
 
 .italics {
   color: #136c97;
-  font-size: 14px;
+  font-size: calc(14rem / 16);
   font-weight: 500;
 }
 

--- a/src/_sass/_base.scss
+++ b/src/_sass/_base.scss
@@ -77,7 +77,7 @@ h4,
 }
 
 .subtext {
-  color: $primary-blue;
+  color: $primary;
   font-size: calc(14rem / 16);
   font-weight: 500;
 }

--- a/src/_sass/_base.scss
+++ b/src/_sass/_base.scss
@@ -76,6 +76,12 @@ h4,
   font-size: calc(16rem / 16);
 }
 
+.italics {
+  color: #136c97;
+  font-size: 14px;
+  font-weight: 500;
+}
+
 hr {
   margin-bottom: map-get($spacers, 4);
   margin-top: map-get($spacers, 4);

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -45,13 +45,13 @@ new_technology:
       To do this, most require data access. These data plans are available to agencies with the pre-negotiated rates listed.
 ---
 
-<p>
+<p class="pb-3">
   The State of California has Master Service Agreements (MSAs) available to help you modernize your transit system.  To add contactless fare collection, you will need up to three new technologies and ensure internet connectivity on your fleet (if you don’t already have it).
 </p>
 
-<strong class="h4 block">Become GTFS Compliant first for best results</strong> <em class="italic">Highly recommended</em>
+<strong class="h4">Become GTFS Compliant first for best results</strong> <em class="italics">Highly recommended</em>
 
-<p>We recommend creating an action plan for becoming GTFS-ready before going contactless, as the vendors you select can help you use this data for reporting puerposes plus help your customers see your real-time vehicle location and fare information on journey-planning smartphone maps and apps.</p>
+<p class="mt-3">We recommend creating an action plan for becoming GTFS-ready before going contactless, as the vendors you select can help you use this data for reporting puerposes plus help your customers see your real-time vehicle location and fare information on journey-planning smartphone maps and apps.</p>
 
 <p class="mt-4 mb-60px">
   <a

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -49,7 +49,7 @@ new_technology:
   The State of California has Master Service Agreements (MSAs) available to help you modernize your transit system.  To add contactless fare collection, you will need up to three new technologies and ensure internet connectivity on your fleet (if you don’t already have it).
 </p>
 
-<strong class="h4">Become GTFS Compliant first for best results</strong> <em class="italics">Highly recommended</em>
+<strong class="h4">Become GTFS Compliant first for best results</strong> <em class="subtext">Highly recommended</em>
 
 <p class="mt-3">We recommend creating an action plan for becoming GTFS-ready before going contactless, as the vendors you select can help you use this data for reporting puerposes plus help your customers see your real-time vehicle location and fare information on journey-planning smartphone maps and apps.</p>
 

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -46,13 +46,14 @@ new_technology:
 ---
 
 <p>
-  The State of California has Master Service Agreements (MSAs) available to help you modernize your transit system.
-  We recommend creating an action plan for becoming GTFS-ready before going contactless, as the vendors you select
-  can help you use this data for reporting purposes plus help your customers see your real-time vehicle location and
-  fare information on journey-planning smartphone maps and apps.
+  The State of California has Master Service Agreements (MSAs) available to help you modernize your transit system.  To add contactless fare collection, you will need up to three new technologies and ensure internet connectivity on your fleet (if you don’t already have it).
 </p>
 
-<p class="my-4">
+<strong>Become GTFS Compliant first for best results</strong> <em>Highly recommended</em>
+
+<p>We recommend creating an action plan for becoming GTFS-ready before going contactless, as the vendors you select can help you use this data for reporting puerposes plus help your customers see your real-time vehicle location and fare information on journey-planning smartphone maps and apps.</p>
+
+<p class="my-4 mb-60px">
   <a
     href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
     class="btn btn-outline-primary"
@@ -60,11 +61,6 @@ new_technology:
   >
     Learn how to become GTFS-compliant
   </a>
-</p>
-
-<p class="mb-60px">
-  To add contactless fare collection, you will need up to three new technologies and ensure internet connectivity on your
-  fleet (if you don’t already have it):
 </p>
 
 {% for technology in page.new_technology %}

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -49,7 +49,7 @@ new_technology:
   The State of California has Master Service Agreements (MSAs) available to help you modernize your transit system.  To add contactless fare collection, you will need up to three new technologies and ensure internet connectivity on your fleet (if you don’t already have it).
 </p>
 
-<strong class="h4">Become GTFS Compliant first for best results</strong> <em class="subtext">Highly recommended</em>
+<strong class="h4">Become GTFS-compliant first for best results</strong> <em class="subtext">Highly recommended</em>
 
 <p class="mt-3">We recommend creating an action plan for becoming GTFS-ready before going contactless, as the vendors you select can help you use this data for reporting puerposes plus help your customers see your real-time vehicle location and fare information on journey-planning smartphone maps and apps.</p>
 

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -49,11 +49,11 @@ new_technology:
   The State of California has Master Service Agreements (MSAs) available to help you modernize your transit system.  To add contactless fare collection, you will need up to three new technologies and ensure internet connectivity on your fleet (if you don’t already have it).
 </p>
 
-<strong>Become GTFS Compliant first for best results</strong> <em>Highly recommended</em>
+<strong class="h4 block">Become GTFS Compliant first for best results</strong> <em class="italic">Highly recommended</em>
 
 <p>We recommend creating an action plan for becoming GTFS-ready before going contactless, as the vendors you select can help you use this data for reporting puerposes plus help your customers see your real-time vehicle location and fare information on journey-planning smartphone maps and apps.</p>
 
-<p class="my-4 mb-60px">
+<p class="mt-4 mb-60px">
   <a
     href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
     class="btn btn-outline-primary"


### PR DESCRIPTION
closes #376 

## What this PR does
- Typography: Adds `.h4` class
- Typography change: Make the css better reflect the new Type guide on Figma. The font family for H1 - H3 is Raleway, and H4 and below is Poppins.
- Typography: Adds `.subtext` class to represent the `Highly recommended` type style, to be used with `<em>` or `<span>`


## Screenshots
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/206062602-f769e6cc-6007-4fa1-b68a-e572a3ffdcd6.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/206062628-2d4847a8-779c-4d76-9f23-069a9f2c8998.png">
