### PR TITLE
Fix: Docker/VS Code issue

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -4,8 +4,5 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     command: sleep infinity
-    ports:
-      - "4000"
-      - "35729:35729"
     volumes:
       - ..:/usr/src/mobimart

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Auto rebuild/reload will be active and will watch the site files for changes.
 
 \* Try using <kbd>cmd</kbd> and clicking on the server address from the Terminal
 
-Note: If the above steps are not working, use [VS Code version 1.72](https://code.visualstudio.com/updates/v1_72)
-
 ## License
 
 Content (including graphics, images, video, documents, and text) in this repository is licensed under [CC-BY 4.0][content-license].


### PR DESCRIPTION
closes #397 

## What this PR does
- Remove `ports` config from compose.yml

Thanks to @angela-tran for figuring this out!!!

## How to test
- Run this app locally with the latest VS Code
- Rebuild + Reopen in Container
- Run Rake task
- When the rake task is complete, click PORTS in VS Code - the bubble should be green. `http://localhost:4000/` should open:
<img width="1485" alt="image" src="https://user-images.githubusercontent.com/3673236/209025460-98454f53-ed04-4896-aff1-91422eeed2fb.png">
