### PR TITLE
Background color for Go Contactless page

### DIFF
--- a/src/_sass/_utilities.scss
+++ b/src/_sass/_utilities.scss
@@ -21,6 +21,19 @@ $mm-dark-tan: rgb(246, 243, 237);
   color: red;
 }
 
+.bg-dark-blue {
+  background-color: $dark-blue;
+}
+
+.btn.btn-dark-blue-inverted {
+  background-color: #ffffff;
+  color: $dark-blue;
+  &:hover {
+    background-color: $gray-1;
+    color: $dark-blue;
+  }
+}
+
 // Extend Bootstrap's container class by just setting some known widths for our
 // "skinny" page container.
 .container--skinny {

--- a/src/_sass/_variables.scss
+++ b/src/_sass/_variables.scss
@@ -18,6 +18,12 @@ $primary: #046b99;
 $success: #0c8547;
 $hover-color: #035376;
 
+// New colors from 2023 / Figma
+
+$dark-blue: #225173;
+
+$gray-1: #eeeeee;
+
 $text-color: #323a45;
 $headings-color: $text-color;
 $code-color: $text-color !important;

--- a/src/how-to/go-contactless.html
+++ b/src/how-to/go-contactless.html
@@ -5,33 +5,23 @@ class_name: no-footer how-to-go-contactless
 show_newsletter: false
 ---
 
-<section class="go-contactless-section">
+<section class="go-contactless-section bg-dark-blue">
   <div class="row justify-content-center">
     <div class="col-md-8">
       <header>
-        <h1 class="page-header">How to Go Contactless</h1>
+        <h1 class="page-header text-white">How to Go Contactless</h1>
       </header>
-      <p>
+      <p class="text-white">
         California is making it easier for public transit providers to accept contactless credit/debit/prepaid cards or mobile
         wallets on a smart device through Master Service Agreements (MSAs) established by the California Department of General
         Services (DGS). Transit providers can take advantage of the MSAs to purchase the key hardware and software needed to
         accept contactless payments.
       </p>
-      <p>Reach out to us for support at any time as your agency explores these resources.</p>
-      <div class="mx-auto text-center">
-        <a class="btn btn-primary" href="#toc-and-content">View guide</a>
+      <p class="text-white">Reach out to us for support at any time as your agency explores these resources.</p>
+      <div class="mx-auto text-center pt-4">
+        <a class="btn btn-dark-blue-inverted" href="#toc-and-content">View guide</a>
       </div>
     </div>
-  </div>
-</section>
-
-<section class="go-contactless-hero px-10vw">
-  <div class="go-contactless-hero__inner">
-    <img
-      alt="Artistic rendering of woman paying with a credit card for coffee and public transportation"
-      class="img-fluid"
-      src="/uploads/hero.svg"
-    />
   </div>
 </section>
 


### PR DESCRIPTION
#407 

This PR removes the image from the Go Contactless (and for future pages with the same layouts), and replaces it with a new dark blue background color. This layout will be used on all future pages with this layout, like the upcoming new Get Connected page, in progress here: #406 

I wanted to separate this change out in its own PR, so it can go out faster.

## What this PR does

Utilities:
- This PR adds new variables: `$dark-blue` for `#225173` and `$gray-1` for `#eeeeee`. These come from the [Figma board's Styleguide page](https://www.figma.com/file/TfWk1iDHdlt7bSA3DjQuQv/Mobility-Marketplace?node-id=3725%3A10998&t=hgCWHxVnkijRGsKR-0)
- And new corresponding utility styles: `.bg-dark-blue`, `.btn-dark-blue-inverted`

## Screenshots
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/214186130-2b5664b3-f0db-4207-9da2-67fe460d767c.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/214186216-15044682-76ae-4a8f-b1ab-52e67647834d.png">
