### PR TITLE
Replace and redirect NASPO pdf link with how-to/get-connected link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,9 +6,7 @@
     environment = { JEKYLL_ENV = "production" }
 
 [[redirects]]
-  from = "//assets/Cal-ITP.MobilityMarketplace.DataPlans.NASPO.FirstNet.pdf"
+  from = "/assets/Cal-ITP.MobilityMarketplace.DataPlans.NASPO.FirstNet.pdf"
   to = "/how-to/get-connected"
   status = 301
   force = false
-  query = {path = ":path"}
-  conditions = {Language = ["en"], Country = ["US"], Role = ["admin"]}

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,11 @@
 
 [context.production]
     environment = { JEKYLL_ENV = "production" }
+
+[[redirects]]
+  from = "//assets/Cal-ITP.MobilityMarketplace.DataPlans.NASPO.FirstNet.pdf"
+  to = "/how-to/get-connected"
+  status = 301
+  force = false
+  query = {path = ":path"}
+  conditions = {Language = ["en"], Country = ["US"], Role = ["admin"]}

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,4 @@
   from = "/assets/Cal-ITP.MobilityMarketplace.DataPlans.NASPO.FirstNet.pdf"
   to = "/how-to/get-connected"
   status = 301
-  force = false
+  force = true # COMMENT: ensure that we always redirect

--- a/src/_data/contracts.yml
+++ b/src/_data/contracts.yml
@@ -72,7 +72,7 @@ entries:
       - 1
 
   - contract: NASPO
-    contract_url: /assets/Cal-ITP.MobilityMarketplace.DataPlans.NASPO.FirstNet.pdf
+    contract_url: /how-to/get-connected/
     vendor: FirstNet
     category: Connectivity
     product: Data Plans


### PR DESCRIPTION
closes #402 

- Users who go to the Contracts page and click `NASPO` will be taken to https://www.camobilitymarketplace.org/how-to/get-connected
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/214927873-65c8f15e-27bb-4b24-813a-1a9e755122f3.png">

- Adds a Netlify redirect so people going to `/assets/Cal-ITP.MobilityMarketplace.DataPlans.NASPO.FirstNet.pdf` get redirected to `/how-to/get-connected`. Test here: https://deploy-preview-410--cal-itp-mobility-marketplace.netlify.app/assets/Cal-ITP.MobilityMarketplace.DataPlans.NASPO.FirstNet.pdf