### PR TITLE
feat(analytics): update Google Analytics to v4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ description: >-
 exclude:
   - _data/
 fonts: "family=Poppins:wght@400;500;700&family=Raleway:wght@700"
-google_analytics_id: "UA-176840950-1"
+google_analytics_id: "G-6M5TSH3VCY"
 mailing_list: https://lp.constantcontactpages.com/su/eLbtFoE/calitp?source_id=a41b99cd-7f28-4be8-a286-f9e75fc7bbce&source_type=em&c=
 navigation:
   header:

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -52,16 +52,14 @@
     <script src="https://code.jquery.com/jquery-migrate-3.3.1.min.js" type="text/javascript"></script>
     <script defer src="https://california.azureedge.net/cdt/statetemplate/5.5.17/js/cagov.core.js"></script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <!-- Google tag (gtag.js) - Version 4, updated 2023 -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{site.google_analytics_id}}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-      gtag("config", "{{site.google_analytics_id}}");
+      gtag('config', '{{site.google_analytics_id}}');
 
       function handleDownloadClick(event_label) {
         gtag("event", "download", {


### PR DESCRIPTION
closes #417 

This PR is the code portion of #417. Further configuration from Analytics admin is required.

## GA set up progress
![Image](https://user-images.githubusercontent.com/3673236/218854783-819042e4-969f-4e2f-9cf6-3635c2668d8e.png)

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/218857465-e198992d-7e7d-4e7a-994d-56922b3e3384.png">

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/218857626-06fdc9a3-e7a3-496c-9894-86a313ba51b0.png">
This PR takes care of the first item: `Collect event data by adding the Google tag to your web pages.`.

## How to test this PR
1. Ensure ID from the code matches that in GA Admin
2. After this PR is closed, go into GA Admin and check that events are coming in
