### PR TITLE
Fix: Provider map table

### DIFF
--- a/src/_sass/_functions.scss
+++ b/src/_sass/_functions.scss
@@ -125,3 +125,25 @@
     }
   }
 }
+
+// Characters which are escaped by the escape-svg function
+$escaped-characters: (("<", "%3c"), (">", "%3e"), ("#", "%23"), ("(", "%28"), (")", "%29")) !default;
+
+// See https://codepen.io/kevinweber/pen/dXWoRw
+//
+// Requires the use of quotes around data URIs.
+
+@function escape-svg($string) {
+  @if str-index($string, "data:image/svg+xml") {
+    @each $char, $encoded in $escaped-characters {
+      // Do not escape the url brackets
+      @if str-index($string, "url(") == 1 {
+        $string: url("#{str-replace(str-slice($string, 6, -3), $char, $encoded)}");
+      } @else {
+        $string: str-replace($string, $char, $encoded);
+      }
+    }
+  }
+
+  @return $string;
+}

--- a/src/_sass/index.scss
+++ b/src/_sass/index.scss
@@ -1,7 +1,7 @@
 @charset "utf-8";
 
 @import "variables";
-@import "breakpoints";
+@import "functions";
 
 @import "../../submodules/tabulator/src/scss/bootstrap/tabulator_bootstrap4.scss";
 

--- a/src/_sass/overrides/_tables.scss
+++ b/src/_sass/overrides/_tables.scss
@@ -70,6 +70,6 @@ td a {
   height: 45px !important;
 }
 
-.tabulator .tabulator-header .tabulator-col .tabulator-col-content {
+#contracts .tabulator .tabulator-header .tabulator-col .tabulator-col-content {
   padding: 0.325rem !important;
 }


### PR DESCRIPTION
fixes #425 

## What this PR does
- Brings back a Bootstrap Sass function `escape-svg` so that the `@escape-svg` works properly for the down/up arrows on the Provider Map
- Removes regression in the table header cell vertical center alignment, by specifying a fix for only the Contracts table
- Renames `breakpoints` file to be more generalized, to all `functions`

## What to look out for

- Arrow display, vertical alignment of table header cells
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/221038837-cee5e3d9-89ea-4e40-b274-42b46e9d1c48.png">
- Vertical alignment of table header cells
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/221038963-e8745593-aade-4eec-bd66-e95b6646e4d6.png">
- Vertical alignmenet of table header cells
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/221045238-0994eda6-256f-46d6-aa1a-e3f4bd7489bd.png">

