### PR TITLE
Fix: On confirmation page, hide all forms

### DIFF
--- a/src/_sass/overrides/_forms.scss
+++ b/src/_sass/overrides/_forms.scss
@@ -11,6 +11,10 @@
   #contact-form-tab fieldset {
     display: none;
   }
+
+  .submitted-message {
+    text-align: center;
+  }
 }
 
 .hbspt-form {

--- a/src/_sass/overrides/_forms.scss
+++ b/src/_sass/overrides/_forms.scss
@@ -7,6 +7,12 @@
   color: $warning;
 }
 
+#contact-container:has(.submitted-message) {
+  #contact-form-tab fieldset {
+    display: none;
+  }
+}
+
 .hbspt-form {
   label,
   .hs-field-desc {

--- a/src/contact.html
+++ b/src/contact.html
@@ -30,7 +30,7 @@ layout: default
   </div>
 </div>
 
-<div class="container container--skinny">
+<div id="contact-container" class="container container--skinny">
   <div class="nav flex-column mt-5 pt-3 mb-4" id="contact-form-tab" role="tablist" aria-orientation="vertical">
     <fieldset>
       <legend><span>I am a</span><span class="required-label" aria-hidden="true">*</span></legend>


### PR DESCRIPTION
closes #435 

## What this PR does
- After the form is submitted, make sure to *hide* the `I am a...` question.
- ⚠️ **Test this PR in Chrome** ⚠️ 
- This PR uses the CSS `:has` selector, which is not supported on Firefox yet, but is supported on Chrome, Edge and Safari. Firefox is only used by 2% of the global population. https://caniuse.com/#feat=css-has Firefox allows users to turn on an experimental flag to turn `has` support on, and full support seems to be coming soon though. (https://twitter.com/alexlehner42/status/1636409643416133633, https://bugzilla.mozilla.org/show_bug.cgi?id=1820835, https://phabricator.services.mozilla.com/D172019) For now, I am comfortable with this fix b/c the vast majority of MobiMart users use Chrome or Edge: https://analytics.google.com/analytics/web/#/p353734172/reports/explorer?params=_u..nav%3Dmaui&r=user-technology-detail&ruid=user-technology-detail,user,technology&collectionId=user

## Screenshots
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3673236/228906346-350a667f-9957-4888-86b2-726fe96b7191.png">
