### PR TITLE
Refactor: replace link to Google Doc with PDF

### DIFF
--- a/src/_data/how_to/get_connected.yml
+++ b/src/_data/how_to/get_connected.yml
@@ -20,7 +20,7 @@ toc:
       - title: How do I get started?
         url: "how-do-I-get-started"
         paragraphs:
-          - text: We welcome you to browse this guide to understand the process and your next steps. Data plans can be found on our <a href="/contracts/view?contracts-filter-product=Data Plans">contracts</a> page. If you are interested in purchasing the FirstNet data plans, self-serve instructions can be found <a href="https://docs.google.com/document/d/1f9mvRPx1Zd2lDJgkIiDQjtVF3uxidFYTOHmRAdxLX88/edit" target="_blank">here</a>.
+          - text: We welcome you to browse this guide to understand the process and your next steps. Data plans can be found on our <a href="/contracts/view?contracts-filter-product=Data Plans">contracts</a> page. If you are interested in purchasing the FirstNet data plans, self-serve instructions can be found <a href="https://resources.calitp.org/mobility-marketplace/FirstNet-Self-Service-Instructions.pdf" target="_blank">here</a>.
           - text: Should you have additional questions or want support in implementing data plans for your fleet, we ask that you complete our contact form for Cal-ITP support.
           - text: <a href="/contact" class="mb-4 mt-3 btn btn-outline-primary">Contact us</a>
   - title: Choosing a data plan


### PR DESCRIPTION
Closes #473 

I uploaded the PDF from https://github.com/cal-itp/mobility-marketplace/issues/473#issuecomment-1731677403 to our storage bucket so the resource lives at `resources.calitp.org`.