### PR TITLE
Add a better workaround so providers.csv isn't polluted

### DIFF
--- a/.github/resources/download_csv.sh
+++ b/.github/resources/download_csv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+bq query \
+    --quiet \
+    --headless \
+    --format=csv \
+    --use_legacy_sql=false \
+    --max_rows=500 \
+    "SELECT * FROM \`mart_transit_database.dim_mobility_mart_providers\`" \
+> src/metadata/providers/providers.csv

--- a/.github/resources/process_providers.py
+++ b/.github/resources/process_providers.py
@@ -21,7 +21,7 @@ for record in lookup_records:
   except KeyError:
     print("No county found for city: ", city)
 
-df.to_csv(providers_file)
+df.to_csv(providers_file, index=False)
 
 # Do a group by for the counties served
 county_counts = df['counties_served'].str.split(';') \

--- a/.github/workflows/provider-map-jobs.yml
+++ b/.github/workflows/provider-map-jobs.yml
@@ -33,14 +33,7 @@ jobs:
           bq show
 
           # Download the latest providers.csv from the warehouse
-          bq query \
-              --quiet \
-              --headless \
-              --format=csv \
-              --use_legacy_sql=false \
-              --max_rows=500 \
-              "SELECT * FROM \`mart_transit_database.dim_mobility_mart_providers\`" \
-          > src/metadata/providers/providers.csv
+          bash .github/resources/download_csv.sh
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/provider-map-jobs.yml
+++ b/.github/workflows/provider-map-jobs.yml
@@ -22,6 +22,17 @@ jobs:
 
       - name: Download providers.csv from warehouse
         run: |
+          # Log what version of the BigQuery CLI we're using
+          bq version
+
+          # An idiotic workaround so that `bq` will not pollute our CSV file with
+          # a welcome message that is COMPLETELY ignored by `--quiet`, `--headless`,
+          # and every other flag that implies "silence unnecessary output."
+          #
+          # https://stackoverflow.com/q/73177304
+          bq show
+
+          # Download the latest providers.csv from the warehouse
           bq query \
               --quiet \
               --headless \
@@ -30,12 +41,6 @@ jobs:
               --max_rows=500 \
               "SELECT * FROM \`mart_transit_database.dim_mobility_mart_providers\`" \
           > src/metadata/providers/providers.csv
-
-      - name: Fix our CSV file
-        run: |
-          # Workaround because of...
-          #   https://issuetracker.google.com/issues/315160970
-          sed -i -n -e '/agency_name/,$p' src/metadata/providers/providers.csv
 
       - uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ Auto rebuild/reload will be active and will watch the site files for changes.
 
 \* Try using <kbd>cmd</kbd> and clicking on the server address from the Terminal
 
+### Debugging the Transit Providers CSV file
+
+The automated process to fetch providers from the data warehouse consists of two parts. The first part is downloading the data as a CSV file from the warehouse. The second part is preparing the data with some Python.
+
+```bash
+# Download the data
+bash .github/resources/download_csv.sh
+
+# (Optional) Don't pollute your global Python install
+virtualenv .github/resources/venv
+source .github/resources/venv/bin/activate
+
+# Install Python dependencies
+pip install -r .github/resources/requirements.txt
+
+# Run the Python script with all the preparing logic
+python .github/resources/process_providers.py
+```
+
 ## Documents
 
 This site uses Google Cloud to manage static files, like the PDFs on the How To pages.


### PR DESCRIPTION
An idiotic (but better than sed) workaround so that `bq` will not pollute our CSV file with a welcome message that is COMPLETELY ignored by `--quiet`, `--headless`, and every other flag that implies "silence unnecessary output."

see https://stackoverflow.com/q/73177304