### PR TITLE
Sort provider map query by NTD ID

### DIFF
--- a/.github/resources/download_csv.sh
+++ b/.github/resources/download_csv.sh
@@ -6,5 +6,5 @@ bq query \
     --format=csv \
     --use_legacy_sql=false \
     --max_rows=500 \
-    "SELECT * FROM \`mart_transit_database.dim_mobility_mart_providers\`" \
+    "SELECT * FROM \`mart_transit_database.dim_mobility_mart_providers\` ORDER BY \`ntd_id\`" \
 > src/metadata/providers/providers.csv


### PR DESCRIPTION
Looking at PRs #538, #541, #513, and gang shows no rhyme or reason behind the order of the CSV file. This makes it annoying and impossible to see the diffs between each pull, so this PR sorts the providers by NTD ID.

**Note:** PR #541 has been corrected to be in sorted order