### PR TITLE
Don't trigger empty PRs for Provider Map updates

### DIFF
--- a/.github/workflows/provider-map-jobs.yml
+++ b/.github/workflows/provider-map-jobs.yml
@@ -44,7 +44,10 @@ jobs:
           pip install -r .github/resources/requirements.txt
           python .github/resources/process_providers.py
 
+      # This step automatically formats code but will fail if it makes changes, so
+      # we use `continue-on-error: true` to ensure the workflow continues.
       - name: Run pre-commit formatters
+        continue-on-error: true
         uses: pre-commit/action@v3.0.1
 
       - name: Create Pull Request

--- a/.github/workflows/provider-map-jobs.yml
+++ b/.github/workflows/provider-map-jobs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Authenticate with Google
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          credentials_json: "${{ secrets.GCP_SA_KEY }}"
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -37,12 +37,15 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies, process providers, and update GeoJSON
         run: |
           pip install -r .github/resources/requirements.txt
           python .github/resources/process_providers.py
+
+      - name: Run pre-commit formatters
+        uses: pre-commit/action@v3.0.1
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
Add the `pre-commit` Action to our provider job so that the generated files are formatted in the same commit after it touches them. This will prevent future empty PRs from being created when the only diff is a newline due to formatting, and our pre-commit makes a second commit "undoing" the lack of a newline in the generated code.

I left a comment in my changes, but I want to point out that we need to allow the pre-commit step to continue despite failure because it will always fail whenever it formats files. We don't care about it "failing" since it'll have fixed our files already anyway.

Closes #550
