### PR TITLE
fix(nav): the for-vendors link can be set to current

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ navigation:
     - name: Contracts
       url: /contracts/
     - name: For vendors
-      url: /for-vendors/
+      url: /for-vendors
     - name: About
       url: /about
     - name: Contact us


### PR DESCRIPTION
fixes #573 

There was a small bug in the menu code that was preventing the For Vendors link from being highlighted when you're on that page. The menu should highlight the current page you are on.

## Branch Preview vs. Prod
Branch Preview https://deploy-preview-575--cal-itp-mobility-marketplace.netlify.app/for-vendors
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/101c0bc9-2b6b-4b64-91d1-c0d225bedc69">


Production
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/f505abe1-5346-40e4-ab66-33bbfccd1cc9">
