### PR TITLE
Homepage announcements are now configured with _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,12 @@ collections:
     permalink: /:title
 description: >-
   A resource to help transit providers upgrade their fare collection systems to accept contactless payment methods like credit/debit cards and smartphones.
+announcement:
+  enabled: true
+  text: |
+    Cal-ITP is offering smaller providers in California a limited number of free
+    licenses to Remix’s suite of scheduling products. Check your eligibility and
+    sign up using our [intake form](https://share.hsforms.com/13WkzY7taSoSdxBATWsNedQ3aanu){:target="_black"}.
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/src/_includes/alert.html
+++ b/src/_includes/alert.html
@@ -1,5 +1,5 @@
 <div class="alert alert-light {{ include.display }}" role="alert">
   <div class="container fs-7">
-    {{ include.text | markdownify }}
+    {{ include.text | markdownify | remove: '<p>' | remove: '</p>' }}
   </div>
 </div>

--- a/src/_includes/alert.html
+++ b/src/_includes/alert.html
@@ -1,5 +1,5 @@
 <div class="alert alert-light {{ include.display }}" role="alert">
   <div class="container fs-7">
-    <!-- Alert text goes here -->
+    {{ include.text | markdownify }}
   </div>
 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,9 @@ show_newsletter: true
 newsletter_background: bg-white
 ---
 
-{% include alert.html display="d-none" %}
+{% if site.announcement.enabled %}
+  {% include alert.html text=site.announcement.text %}
+{% endif %}
 
 <div class="container">
   <div class="imaged-section imaged-section--right">


### PR DESCRIPTION
Add Remix announcement banner as a configurable setting in `_config.yml` so that we no longer have to touch multiple files to had an announcement.

Closes #564
