### PR TITLE
Fix: GTFS link on Contracts page

### DIFF
--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -78,7 +78,7 @@ new_technology:
 
 <p class="mb-60px">
   <a
-    href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
+    href="https://dot.ca.gov/cal-itp/california-transit-data-guidelines/"
     class="btn btn-outline-primary"
     target="_blank"
   >


### PR DESCRIPTION
closes #602 

- Changes link to a new link
- Not part of this PR: DOT team will make sure the old link https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines redirects to https://dot.ca.gov/cal-itp/california-transit-data-guidelines