### PR TITLE
GTFS-RT: Add 3 contracts

### DIFF
--- a/src/_data/contracts.yml
+++ b/src/_data/contracts.yml
@@ -87,3 +87,27 @@ entries:
     product: Data Plans
     user_instructions: ~
     footnotes: ~
+
+  - contract: 5-24-70-42-01
+    contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-01
+    vendor: Connexionz Ltd
+    category: GTFS
+    product: GTFS-RT
+    user_instructions: ~
+    footnotes: ~
+
+  - contract: 5-24-70-42-02
+    contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02
+    vendor: Passio Technologies LLC
+    category: GTFS
+    product: GTFS-RT
+    user_instructions: ~
+    footnotes: ~
+
+  - contract: 5-24-70-42-03
+    contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-03
+    vendor: Swiftly Inc
+    category: GTFS
+    product: GTFS-RT
+    user_instructions: ~
+    footnotes: ~

--- a/src/contracts/view.html
+++ b/src/contracts/view.html
@@ -23,7 +23,7 @@ class_name: no-banner
       The State of California has Master Service Agreements (MSAs) available
       to help you modernize your transit system. Click the contract number below to view all Master Service
       Agreement (MSA) documentation. If you need further assistance as you make your selections,
-      you can <a href="/contact">get in touch</a> with <span class="no-word-break">Cal-ITP</span>.
+      you can <a href="/contact">email us</a>.
     </p>
   </article>
 </div>


### PR DESCRIPTION
closes #454 

## What this PR does
- Add 3 contracts, in the GTFS category, and the GTFS-RT product
- Changes 1 sentence on the contracts page template, which affects all the contract pages.

## Screenshots

### `/contracts/view?contracts-filter-product=GTFS-RT`
![image](https://github.com/user-attachments/assets/fbc1e834-26c2-4dca-81c5-944f19f90274)

## all contracts pages have this sentence change
![image](https://github.com/user-attachments/assets/bb795bbd-a31f-492d-a8c3-765fb35a0a61)
