### PR TITLE
Fix: Contracts page fixes

### DIFF
--- a/src/_data/contracts.yml
+++ b/src/_data/contracts.yml
@@ -92,7 +92,7 @@ entries:
     contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-01
     vendor: Connexionz Ltd
     category: GTFS
-    product: GTFS-RT
+    product: GTFS-Realtime
     user_instructions: ~
     footnotes: ~
 
@@ -100,7 +100,7 @@ entries:
     contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02
     vendor: Passio Technologies LLC
     category: GTFS
-    product: GTFS-RT
+    product: GTFS-Realtime
     user_instructions: ~
     footnotes: ~
 
@@ -108,6 +108,6 @@ entries:
     contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-03
     vendor: Swiftly Inc
     category: GTFS
-    product: GTFS-RT
+    product: GTFS-Realtime
     user_instructions: ~
     footnotes: ~

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -17,7 +17,7 @@ new_technology:
   - icon: gtfs-realtime.svg
     icon-alt: Bus with a GPS location icon
     title: GTFS-Realtime
-    url: ./view?contracts-filter-product=GTFS-RT
+    url: ./view?contracts-filter-product=GTFS-Realtime
     button: View contracts
     content: >
       Software (and optional hardware) contracts that allow transit agencies to provide standardized real-time vehicle location data to their riders, who can then confidently plan their transit trips.

--- a/src/contracts/view.html
+++ b/src/contracts/view.html
@@ -23,7 +23,7 @@ class_name: no-banner
       The State of California has Master Service Agreements (MSAs) available
       to help you modernize your transit system. Click the contract number below to view all Master Service
       Agreement (MSA) documentation. If you need further assistance as you make your selections,
-      you can <a href="/contact">email us</a>.
+      you can <a href="mailto:hello@calitp.org&subject=Question%20about%20contracts">email us</a>.
     </p>
   </article>
 </div>

--- a/src/contracts/view.html
+++ b/src/contracts/view.html
@@ -23,7 +23,7 @@ class_name: no-banner
       The State of California has Master Service Agreements (MSAs) available
       to help you modernize your transit system. Click the contract number below to view all Master Service
       Agreement (MSA) documentation. If you need further assistance as you make your selections,
-      you can <a href="mailto:hello@calitp.org&subject=Question%20about%20contracts">email us</a>.
+      you can <a href="mailto:hello@calitp.org?subject=Question%20about%20contracts">email us</a>.
     </p>
   </article>
 </div>


### PR DESCRIPTION
closes #625 

## What this PR does

This PR addresses 2 specific changes on the contract filtered page:
- The `email us` link now will direct users to email `hello@calitp.org` with a subject line of `Questions about contract`
- The Product category is now called `GTFS-Realtime`, changed from `GTFS-RT`. This affects how the table is displayed, and the URL.

## Screenshots
- Email us link: <img width="1511" alt="image" src="https://github.com/user-attachments/assets/b3447a57-2a21-4481-8860-952fc8e7db6a" />
- GTFS-Realtime name: <img width="1512" alt="image" src="https://github.com/user-attachments/assets/9e989fd2-ec62-4696-bc6e-894f2f3b25c3" />
