### PR TITLE
Contracts: no hyphen between GTFS and Realtime

### DIFF
--- a/src/_data/contracts.yml
+++ b/src/_data/contracts.yml
@@ -92,7 +92,7 @@ entries:
     contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-01
     vendor: Connexionz Ltd
     category: GTFS
-    product: GTFS-Realtime
+    product: GTFS Realtime
     user_instructions: ~
     footnotes: ~
 
@@ -100,7 +100,7 @@ entries:
     contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02
     vendor: Passio Technologies LLC
     category: GTFS
-    product: GTFS-Realtime
+    product: GTFS Realtime
     user_instructions: ~
     footnotes: ~
 
@@ -108,6 +108,6 @@ entries:
     contract_url: https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-03
     vendor: Swiftly Inc
     category: GTFS
-    product: GTFS-Realtime
+    product: GTFS Realtime
     user_instructions: ~
     footnotes: ~

--- a/src/contracts/index.html
+++ b/src/contracts/index.html
@@ -16,8 +16,8 @@ class_name: no-banner
 new_technology:
   - icon: gtfs-realtime.svg
     icon-alt: Bus with a GPS location icon
-    title: GTFS-Realtime
-    url: ./view?contracts-filter-product=GTFS-Realtime
+    title: GTFS Realtime
+    url: ./view?contracts-filter-product=GTFS Realtime
     button: View contracts
     content: >
       Software (and optional hardware) contracts that allow transit agencies to provide standardized real-time vehicle location data to their riders, who can then confidently plan their transit trips.

--- a/src/intro-gtfs-rt.html
+++ b/src/intro-gtfs-rt.html
@@ -131,7 +131,7 @@ newsletter_background: bg-dark-tan
     <p class="mb-2">
       You can adopt GTFS Realtime with your own hardware or purchase directly from vendors via MSAs (Master Service Agreements).
       California DGS competitively awards contracts or MSAs to vendors
-      <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS-Realtime/"
+      <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS Realtime/"
         >offering standardized GTFS Realtime products</a
       >.
     </p>
@@ -150,7 +150,7 @@ newsletter_background: bg-dark-tan
           <h3 class="h4 with-gtfs-realtime d-flex align-items-center">GTFS Realtime with MSAs</h3>
           <p class="m-0">
             California DGS competitively awards MSAs to vendors offering
-            <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS-Realtime">GTFS Realtime products</a>. 
+            <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS Realtime">GTFS Realtime products</a>. 
           </p>
         </div>
       </div>
@@ -194,7 +194,7 @@ newsletter_background: bg-dark-tan
       </li>
       <li class="pb-3">
         <strong>GTFS Realtime</strong> ➞ Learn more and
-        <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS-Realtime">get started with the MSA contracts</a>.
+        <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS Realtime">get started with the MSA contracts</a>.
       </li>
       <li class="pb-0">
         <strong>Data Quality</strong> ➞ Visit
@@ -223,7 +223,7 @@ newsletter_background: bg-dark-tan
         GTFS Schedule
       </li>
       <li>
-        Get started with <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS-Realtime">MSA contracts</a> to
+        Get started with <a target="_blank" href="/contracts/view?contracts-filter-product=GTFS Realtime">MSA contracts</a> to
         establish GTFS Realtime
       </li>
       <li>


### PR DESCRIPTION
fixes #629 

The official style for "GTFS Realtime" has no hyphen between the words.

We are removing "GTFS-Realtime" from the whole app.

![image](https://github.com/user-attachments/assets/6cfa5eec-abd6-4ebe-ab53-638951f84f0f)
![image](https://github.com/user-attachments/assets/735df97a-85d5-42cf-b7b7-0a28da01e4e3)
and all links to this page have been updated.