### PR TITLE
fix: update Netlify badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A one-stop resource for modern, equitable and accessible public transit products and services.
 
-Deployed via [Netlify][netlify] [![Netlify Status](https://api.netlify.com/api/v1/badges/0fcfad48-7c0e-43f4-bb85-f7447f7f5fa6/deploy-status)](https://app.netlify.com/sites/cal-itp-transit-stop/deploys)
+Deployed via [Netlify][netlify] [![Netlify Status](https://api.netlify.com/api/v1/badges/0fcfad48-7c0e-43f4-bb85-f7447f7f5fa6/deploy-status)](https://app.netlify.com/projects/cal-itp-mobility-marketplace/deploys)
 
 ## Development
 


### PR DESCRIPTION
The current README Netlify badge link is incorrect and goes to a 404 page. It should be `projects` and `cal-itp-mobility-marketplace`.

To confirm, log into Netlify and go to https://app.netlify.com/projects/cal-itp-mobility-marketplace/configuration/general#status-badges to check the badge URL