### PR TITLE
feat: Add step list component

### DIFF
--- a/src/demo.md
+++ b/src/demo.md
@@ -47,9 +47,9 @@ description: >
 <div class="container">
   <h2>Step list</h2>
   <div class="row">
-    <h3>Default color scheme (yellow)</h3>
+    <h3>Color scheme: yellow</h3>
     <div class="offset-lg-2 col-lg-6 col-12">
-      <ol class="step-list my-4">
+      <ol class="step-list step-list_yellow my-4">
         <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
         <li><b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on <a href="#">CALNET</a> or on <a href="#">NASPO</a></li>
         <li><b>Engage the vendor</b> you’d like to purchase from</li>

--- a/src/styles/latest.css
+++ b/src/styles/latest.css
@@ -3,6 +3,7 @@
 .pull-quote {
   padding: var(--spacing-5) 0;
   margin: var(--spacing-7) 0;
+  background-color: var(--dsdl-gray-20);
 }
 .pull-quote-content {
   font-family: var(--dsdl-heading-font-stack);
@@ -18,25 +19,20 @@
 .pull-quote-content_attributed::before {
   content: '“';
   display: block;
+  margin-bottom: -0.25em;
+  color: white;
   font-family: var(--dsdl-heading-font-stack);
   font-size: calc(150 / 16 * 1rem);
   line-height: 0.75;
   font-weight: 700;
-  margin-bottom: -0.25em;
 }
 .pull-quote_yellow {
   background-color: var(--calitp-brand-yellow);
   color: var(--dsdl-black);
 }
-.pull-quote_yellow .pull-quote-content_attributed::before {
-  color: white;
-}
 .pull-quote_purple {
   background-color: var(--dsdl-purple-30);
   color: var(--dsdl-black);
-}
-.pull-quote_purple .pull-quote-content_attributed::before {
-  color: white;
 }
 .pull-quote_cyan-light {
   background-color: var(--dsdl-cyan-10);
@@ -70,7 +66,7 @@
 .step-list {
   padding-left: 1.875rem;
   padding-bottom: 1.5rem;
-  border-left: 0.1875rem solid var(--calitp-brand-yellow);
+  border-left: 0.1875rem solid var(--dsdl-gray-20);
   margin-left: 0.9375rem;
   font-size: var(--text-l);
   list-style: none;
@@ -93,7 +89,7 @@
   position: absolute;
   left: -3rem;
   top: -0.0625rem;
-  background-color: var(--calitp-brand-yellow);
+  background-color: var(--dsdl-gray-20);
   color: var(--dsdl-black);
   font-family: var(--dsdl-heading-font-stack);
   font-size: var(--text-m);
@@ -102,6 +98,11 @@
   text-align: center;
 }
 
+.step-list_yellow { border-left-color: var(--calitp-brand-yellow); }
+.step-list_yellow li::before {
+  background-color: var(--calitp-brand-yellow);
+  color: var(--dsdl-black);
+}
 .step-list_purple { border-left-color: var(--dsdl-purple-80);  }
 .step-list_purple li::before {
   background-color: var(--dsdl-purple-80);


### PR DESCRIPTION
ℹ️ **PR is to `staging` branch** ℹ️ 

---

This PR adds the basic version of our styled list for a process with multiple steps (i.e., the condensed version that appears at the top of our guides, not the big list with the details of each step), which I am calling a "step list". Open to naming suggestions.

<img width="1320" height="956" alt="Example step list rendered with purple color scheme" src="https://github.com/user-attachments/assets/a7db6332-5979-4d58-896a-48b52bbbd3e7" />


In contrast to the pull quote component, I elected not to implement this as an include, because it seemed too gnarly / not beneficial enough when you'd have to pass in a full slate of `<li>`s in raw HTML, anyway. Open to disagreement on that, though!

The second commit makes sure that both the step list and pull quote components will render usefully if a `_color` modifier class is omitted from the markup by giving it a default light gray color scheme.