### PR TITLE
feat: Add table styling and examples

### DIFF
--- a/src/demo.md
+++ b/src/demo.md
@@ -48,7 +48,7 @@ description: >
   <h2>Step list</h2>
   <div class="row">
     <h3>Color scheme: yellow</h3>
-    <div class="offset-lg-2 col-lg-6 col-12">
+    <div class="offset-lg-2 col-lg-7 col-12">
       <ol class="step-list step-list_yellow my-4">
         <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
         <li><b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on <a href="#">CALNET</a> or on <a href="#">NASPO</a></li>
@@ -60,7 +60,7 @@ description: >
   </div>
   <div class="row">
     <h3>Color scheme: purple</h3>
-    <div class="offset-lg-2 col-lg-6 col-12">
+    <div class="offset-lg-2 col-lg-7 col-12">
       <ol class="step-list step-list_purple my-4">
         <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
         <li><b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on <a href="#">CALNET</a> or on <a href="#">NASPO</a></li>
@@ -72,7 +72,7 @@ description: >
   </div>
   <div class="row">
     <h3>Color scheme: cyan-light</h3>
-    <div class="offset-lg-2 col-lg-6 col-12">
+    <div class="offset-lg-2 col-lg-7 col-12">
       <ol class="step-list step-list_cyan-light my-4">
         <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
         <li><b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on <a href="#">CALNET</a> or on <a href="#">NASPO</a></li>
@@ -84,7 +84,7 @@ description: >
   </div>
   <div class="row">
     <h3>Color scheme: cyan-dark</h3>
-    <div class="offset-lg-2 col-lg-6 col-12">
+    <div class="offset-lg-2 col-lg-7 col-12">
       <ol class="step-list step-list_cyan-dark my-4">
         <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
         <li><b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on <a href="#">CALNET</a> or on <a href="#">NASPO</a></li>
@@ -95,13 +95,219 @@ description: >
     </div>
   </div>
 
-  <h2>Numbered headings</h2>
   <div class="row">
-    <div class="offset-lg-2 col-lg-6 col-12">
+    <h2>Numbered headings</h2>
+    <div class="offset-lg-2 col-lg-7 col-12">
       <h3 class="numbered numbered_yellow my-4" data-number="1">Choose a data plan</h3>
       <h3 class="numbered numbered_purple my-4" data-number="2">Review purchase options</h3>
       <h3 class="numbered numbered_cyan-light my-4" data-number="3">Reach out to your vendor</h3>
       <h3 class="numbered numbered_cyan-dark my-4" data-number="4">Sign agreement</h3>
+    </div>
+  </div>
+
+  <div class="row">
+    <h2>Tables</h2>
+    <div class="offset-lg-2 col-lg-7 col-12 table-responsive">
+      <h3>Color scheme: yellow</h3>
+      <table class="table_yellow my-4">
+        <thead>
+          <tr>
+            <th scope="col">Vendors</th>
+            <th scope="col">MSAs</th>
+            <th scope="col">Types of transactions</th>
+            <th scope="col">Payment networks</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Fiserv*</td>
+            <td><a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-22-70-22-02&SETID=STATE&VERSION_NBR=2">5-22-70-22-02</a></td>
+            <td>
+              <ul>
+                <li>credit</li>
+                <li>debit</li>
+                <li>mobile wallet</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>American Express</li>
+                <li>Discover</li>
+                <li>Mastercard</li>
+                <li>Visa</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>Elavon*</td>
+            <td><a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-22-70-22-01&SETID=STATE&VERSION_NBR=3">5-22-70-22-01</a></td>
+            <td>
+              <ul>
+                <li>credit</li>
+                <li>debit</li>
+                <li>mobile wallet</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>American Express</li>
+                <li>Discover</li>
+                <li>Mastercard</li>
+                <li>Visa</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+        <caption class="visually-hidden">Payment Processors MSAs (click on each MSA for terms and conditions)</caption>
+      </table>
+      <h3>Color scheme: purple</h3>
+      <table class="table_purple my-4">
+        <thead>
+          <tr>
+            <th scope="row">MSAs</th>
+            <th colspan="3" scope="col"><a href="https://cdt.ca.gov/services/calnet-calitp/">CALNET</a> + <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf">NASPO</a></th>
+            <th scope="col"><a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf">NASPO</a></th>
+          </tr>
+          <tr>
+            <th scope="row">Vendors</th>
+            <th scope="col">AT&T</th>
+            <th scope="col" class="text-nowrap">T-Mobile</th>
+            <th scope="col">Verizon</th>
+            <th scope="col">FirstNet</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">1 GB</th>
+            <td>$20</td>
+            <td>$8</td>
+            <td>$15</td>
+            <td>$7.50</td>
+          </tr>
+          <tr>
+            <th scope="row">2 GB</th>
+            <td>$23</td>
+            <td>$10</td>
+            <td>$20</td>
+            <td>–</td>
+          </tr>
+          <tr>
+            <th scope="row">3 GB</th>
+            <td>–</td>
+            <td>–</td>
+            <td>–</td>
+            <td>$20</td>
+          </tr>
+          <tr>
+            <th scope="row">5 GB</th>
+            <td>$28</td>
+            <td>$21.21</td>
+            <td>$25</td>
+            <td>–</td>
+          </tr>
+          <tr>
+            <th scope="row">25 GB</th>
+            <td>–</td>
+            <td>–</td>
+            <td>–</td>
+            <td>$34</td>
+          </tr>
+          <tr>
+            <th scope="row">100 GB</th>
+            <td>$410</td>
+            <td>$97.57</td>
+            <td>$353.50</td>
+            <td>–</td>
+          </tr>
+          <tr>
+            <th scope="row">Unlimited</th>
+            <td>$50</td>
+            <td>–</td>
+            <td>$34.99</td>
+            <td>–</td>
+          </tr>
+        </tbody>
+        <caption class="visually-hidden">Data plans MSAs (cost per month per vehicle, prices are negotiable, click on each MSA for terms and conditions)</caption>
+      </table>
+      <h3>Color scheme: cyan</h3>
+      <p><i>Note:</i> There is only one cyan color scheme for tables, not both light and dark cyan.</p>
+      <table class="table_cyan wider my-4">
+        <thead>
+          <tr>
+            <th scope="col">MSA vendors</th>
+            <th scope="col">MSAs</th>
+            <th scope="col">Pricing structure</th>
+            <th scope="col">Hardware options</th>
+            <th scope="col">Eligible networks</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Connexionz Ltd</td>
+            <td><a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3">5-24-70-42-01</a></td>
+            <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+            <td>Cellular routing kit (with Pepwave MAX BR1 Mini)</td>
+            <td>
+              <ul>
+                <li>WiFi</li>
+                <li>AT&T</li>
+                <li class="text-nowrap">T-Mobile</li>
+                <li>Verizon</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>Passio Technologies LLC</td>
+            <td><a href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02">5-24-70-42-02</a></td>
+            <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+            <td>
+              <ul>
+                <li>Calamp LMU-3641</li>
+                <li>Lilliput RT-V7000 Pro</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>WiFi</li>
+                <li>AT&T</li>
+                <li class="text-nowrap">T-Mobile</li>
+                <li>Verizon</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td rowspan="2" style="border-bottom: none;">Swiftly Inc</td>
+            <td rowspan="2" style="border-bottom: none;"><a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2">5-24-70-42-03</a></td>
+            <td rowspan="2" style="border-bottom: none;">Variable fees based on number of vehicles</td>
+            <td>Samsara VG55</td>
+            <td>
+              <ul>
+                <li>WiFi</li>
+                <li>AT&T</li>
+                <li>FirstNet</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li>Samsung Tab Active 5</li>
+                <li>Cradlepoint R1900</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>WiFi</li>
+                <li>AT&T</li>
+                <li>FirstNet</li>
+                <li>T-Mobile</li>
+                <li>Verizon</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+        <caption class="visually-hidden">GTFS Realtime MSAs (click on each MSA for terms and conditions)</caption>
+      </table>
     </div>
   </div>
 </div>

--- a/src/styles/latest.css
+++ b/src/styles/latest.css
@@ -151,6 +151,59 @@
   color: white;
 }
 
+/* TABLES */
+
+table {
+  width: 100%;
+  border: 1px solid var(--dsdl-gray-40);
+  border-collapse: separate;
+  border-radius: var(--spacing-05);
+  border-spacing: 0;
+}
+/* Apply a border to the right of all but the last column */
+th:not(:last-child),
+td:not(:last-child) {
+  border-right: 1px solid var(--dsdl-gray-40);
+}
+/* Apply a border to the bottom of all but the last row */
+thead th,
+tr:not(:last-child) > td,
+tbody > tr:not(:last-child) > th {
+  border-bottom: 1px solid var(--dsdl-gray-40);
+}
+td,
+th {
+  padding: calc(var(--spacing-base) * 1.5);  /* 1.25rem (20px) -- add new var --spacing-1-05 var for this? */
+}
+th {
+  background-color: var(--dsdl-gray-20);
+}
+td ul,
+td ol {
+  padding-left: 1em;
+  margin-bottom: 0;
+}
+.table_yellow th {
+  background-color: var(--dsdl-yellow-10);
+}
+.table_purple th {
+  background-color: var(--dsdl-purple-20);
+}
+.table_cyan th {
+  background-color: var(--dsdl-cyan-10);
+}
+.table-responsive {
+  container-name: responsive-table-wrapper;
+  container-type: inline-size;
+}
+
+/* Magic numbers decided based on current table content. */
+@container responsive-table-wrapper (max-width: calc(720rem / 16)) {  /* Variables can't be used here yet. */
+  .wider {
+    min-width: calc(var(--spacing-base) * 120);
+  }
+}
+
 /* HEADER */
 .header {
   background-color: #fff;


### PR DESCRIPTION
Notes:
- Tables default to 100% width (of their container), but will stop shrinking once each column is only as wide as needed for the longest word in that column. At that point, they will overflow the container.
- Bootstrap's responsive table feature enables scrolling when a table overflows its container. - Because certain tables can get too squished horizontally for a readable experience, I added a `.wider` class that can force tables to be wider when their container is below 720px wide. (see the last example on the demo page)
- I have a couple questions in Figma for @cmajel, but they don't necessarily block getting this PR in.