### PR TITLE
feat: Adjust type scale

### DIFF
--- a/src/styles/latest.css
+++ b/src/styles/latest.css
@@ -1,3 +1,43 @@
+/* TYPE SCALE */
+
+/* If these adjustments prove successful, they should be relocated to the DSDL styles in calitp.org. */
+
+h3,
+.h3,
+h4,
+.h4 {
+  font-weight: 700;
+}
+h5,
+.h5 {
+  font-size: calc(18 / var(--text-base) * 1rem);
+  font-weight: 500;
+}
+
+@media (min-width: 992px) {
+  h1,
+  .h1 {
+    font-size: calc(48 / var(--text-base) * 1rem);
+  }
+  h2,
+  .h2 {
+    font-size: var(--text-xxxl);
+  }
+  h3,
+  .h3 {
+    font-size: var(--text-xxl);
+  }
+  h4,
+  .h4 {
+    font-size: var(--text-xl);
+  }
+  small,
+  .small,
+  .text-caption {
+    font-size: var(--text-s);
+  }
+}
+
 /* PULL QUOTE */
 
 .pull-quote {


### PR DESCRIPTION
Follow up to #721

Makes adjustments to type scale per @cmajel's [new specs in Figma](https://www.figma.com/design/TfWk1iDHdlt7bSA3DjQuQv/Mobility-Marketplace?node-id=10714-5867&m=dev).

Specifically:
- H3 and H4: weight is bumped from semi-bold to bold
- H5: weight is reduced from semi-bold to medium and size is set at 18px on all screen sizes
- Desktop widths (>= 992px): Font size bumped up one increment for H1, H2, H3, H4, and small/caption text

If these adjustments prove successful, they should be relocated to the DSDL styles in calitp.org.