### PR TITLE
chore: install ruby gems explicitly during netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-    command = "bundle exec jekyll build"
+    # see https://github.com/cal-itp/mobility-marketplace/pull/765 for more info about why we are calling 'bundle install' explicitly
+    command = "bundle install && bundle exec jekyll build"
     environment = { JEKYLL_ENV = "development" }
 
 [context.production]


### PR DESCRIPTION
## the error:
netlify branch build and deploy previews started breaking yesterday immediately after merging https://github.com/cal-itp/mobility-marketplace/pull/760

i *think* that the netlify.toml file and _redirects on `staging` not matching what is on `main` are putting netlify into some sort of 'strict' mode that causes it to skip calling `bundle install` on its own during initialization.

## the fix:
explicitly asking the bundler to install the dependencies during the build step resolves the problem (and doesn't negate caching).

the change is a little too 'boot and suspenders' for my taste and i'm not as certain as [Gemini](https://docs.google.com/document/d/1mnrGAoL_tnnJCElIM3qRA8vQ_zLyhTFiegnRPx1muTE/edit?usp=sharing) about the actual root cause, but it indeed fixes the problem and seems harmless. particularly since we plan on replacing the netlify build command with a call to 11ty soon. 🤷 