### PR TITLE
chore: prepend calitp.org with www to avoid redirects

### DIFF
--- a/src/_includes/footer/blurb.html
+++ b/src/_includes/footer/blurb.html
@@ -1,4 +1,4 @@
 <p>
   Mobility Marketplace is a collection of guides to modernize California transit with pre-approved MSAs, brought to you by
-  <a class="text-nowrap" href="https://calitp.org">Cal-ITP</a>.
+  <a class="text-nowrap" href="https://www.calitp.org">Cal-ITP</a>.
 </p>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -23,7 +23,7 @@
     <link href="https://fonts.googleapis.com/css2?{{site.fonts}}&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/styles/styles.css" />
 
-    <link rel="stylesheet" href="https://calitp.org/stylesheets/dsdl/dsdl.css" />
+    <link rel="stylesheet" href="https://www.calitp.org/stylesheets/dsdl/dsdl.css" />
     <link rel="stylesheet" href="/styles/latest.css" />
 
     <meta name="theme-color" content="{{site.theme_color}}" />

--- a/src/_layouts/demo.html
+++ b/src/_layouts/demo.html
@@ -21,7 +21,7 @@
       crossorigin="anonymous"
     />
 
-    <link rel="stylesheet" href="https://calitp.org/stylesheets/dsdl/dsdl.css" />
+    <link rel="stylesheet" href="https://www.calitp.org/stylesheets/dsdl/dsdl.css" />
     <link rel="stylesheet" href="/styles/latest.css" />
 
     <meta name="theme-color" content="{{site.theme_color}}" />


### PR DESCRIPTION
this is just something small i noticed last week.

<img width="1050" height="599" alt="Screenshot 2026-01-12 at 10 42 22 AM" src="https://github.com/user-attachments/assets/98d8167f-40b5-47f2-9cb9-368d86195563" />
