### PR TITLE
chore: add second tap to pay related footer link

### DIFF
--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -520,13 +520,11 @@ color_scheme=quote_color_scheme content=quote_content source_name=quote_source_n
         <span class="text">Build on Schedule data with <b>GTFS Realtime</b>. Explore the guide</span>
       </a>
     </div>
-    {% comment %}
     <div class="col-md">
-      <a class="related-nav-link related-nav-link_next" href="/benefits">
-        <span class="text">Make your tap to pay program more robust with rider benefits & discounts</span>
+      <a class="related-nav-link related-nav-link_next" href="/data-plans">
+        <span class="text">Explore how to increase data or save on your data plans</span>
         <span class="arrow" aria-label="(next page)">→</span>
       </a>
     </div>
-    {% endcomment %}
   </nav>
 </div>


### PR DESCRIPTION
@cmajel had the great suggestion to link from Tap to Pay to `/data-plans` until the rider benefits guide is complete.