### PR TITLE
feat: add keyboard accessible 'Skip to main content' link

### DIFF
--- a/src/_layouts/latest.html
+++ b/src/_layouts/latest.html
@@ -36,8 +36,8 @@
     <!-- End Google Tag Manager -->
   </head>
   <body>
-    <div id="skip-to-content">
-      <a class="text-center" href="#main-content">Skip to Main Content</a>
+    <div class="d-flex justify-content-center">
+      <a class="my-1 visually-hidden-focusable" href="#main-content">Skip to Main Content</a>
     </div>
     <div class="d-flex flex-column justify-content-between vh-100">
       <div class="header-wrapper">

--- a/src/styles/latest.css
+++ b/src/styles/latest.css
@@ -1130,17 +1130,3 @@ input[type="checkbox"] {
 .bg-info-yellow {
   background-color: var(--dsdl-yellow-10);
 }
-
-#skip-to-content a {
-  height: 0;
-  left: 50%;
-  overflow: hidden;
-  position: absolute;
-  transform: translateX(-50%);
-  width: 0;
-}
-
-#skip-to-content a:focus {
-  height: 28px;
-  width: 180px;
-}


### PR DESCRIPTION
cribbed from `#main` (and simplified)

on <kbd>Tab</kbd>:
<img width="624" height="191" alt="Screenshot 2026-01-29 at 12 53 38 PM" src="https://github.com/user-attachments/assets/07feb833-3704-42ae-9faa-b26bfeecd7e2" />
