### PR TITLE
Fix: copy for tap to pay

### DIFF
--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -45,10 +45,13 @@ description: >
   </ol>
 </div>
 
-{% assign quote_color_scheme = "yellow" %} {% assign quote_content = "<b>We’re excited to offer tap to pay to make it easy for customers to choose public transportation.</b> Cal-ITP’s free support helped us save the hassle and expense of running our own procurement while modernizing our fare systems with contactless hardware and fare-calculation and payment-processing software." %}
-{% assign quote_source_name = "Greg Pratt" %}
-{% assign quote_source_title = "General Manager, Humboldt Transit Authority" %}
-{% include pull-quote.html color_scheme=quote_color_scheme content=quote_content source_name=quote_source_name source_title=quote_source_title %}
+{% assign quote_color_scheme = "yellow" %} {% assign quote_content = "<b
+  >We’re excited to offer tap to pay to make it easy for customers to choose public transportation.</b
+>
+Cal-ITP’s free support helped us save the hassle and expense of running our own procurement while modernizing our fare systems
+with contactless hardware and fare-calculation and payment-processing software." %} {% assign quote_source_name = "Greg Pratt" %}
+{% assign quote_source_title = "General Manager, Humboldt Transit Authority" %} {% include pull-quote.html
+color_scheme=quote_color_scheme content=quote_content source_name=quote_source_name source_title=quote_source_title %}
 
 <div class="container">
   <h2>Go contactless with tap to pay</h2>
@@ -112,15 +115,13 @@ description: >
     The prices in this workbook are maximums, and transit agencies are strongly encouraged to reach out to vendors directly for
     tailored pricing. Prices may be reduced and/or fee categories waived at vendors’ sole discretion.
   </p>
-  <h3 class="numbered numbered_yellow" data-number="2">Review MSAs</h3>
-  <p class="text-body-xl">
+  <h3 class="numbered numbered_yellow" data-number="2">Assess vendors and review MSAs</h3>
+  <p>
     Agencies can purchase from the MSAs for Payment Acceptance Devices (Category A) and Transit Processor Services (Category B),
     as well as the Electronic Payment Acceptance Services (EPAY) MSAs, to begin accepting contactless open loop payments.
   </p>
-  <h4>Assess vendors</h4>
-  <p class="table-caption">Click on each MSA for terms and conditions.</p>
-
-  <h5 class="h4">PADs (Payment Acceptance Devices) MSAs</h5>
+  <p>Click on each MSA for terms and conditions.</p>
+  <h4>PADs (Payment Acceptance Devices) MSAs</h4>
   <p>
     Onboard, on-platform, and mobile fare inspection devices that are equipped to read riders’ contactless bank cards and smart
     devices.
@@ -184,7 +185,7 @@ description: >
     </caption>
   </table>
 
-  <h5 class="h4">Transit Processors MSAs</h5>
+  <h4>Transit Processors MSAs</h4>
   <p>
     Software that instantly determines the correct fare for a trip based on distance, applicable discounts, and frequency of
     travel.
@@ -490,12 +491,12 @@ description: >
 
   <h4>Not in California?</h4>
   <p>
-    Non-California agencies may still be eligible to purchase hardware and transit processor services. Follow
-    the process described above and incorporate the MSA into your contract. The MSAs listed on this site are examples of a “state
-    purchasing schedule.” These schedules are agreements between a state or related entity and vendor(s) to provide goods or
-    services at agreed-upon prices. Fundamentally, state purchasing schedules are designed to accommodate other parties that may
-    enter into and benefit from the agreements in the future. You’ll sign a contract with the vendors directly. However, the terms
-    and conditions (and pricing!) from the MSA are incorporated by reference in the contract that you will sign. You can use a
+    Non-California agencies may still be eligible to purchase hardware and transit processor services. Follow the process
+    described above and incorporate the MSA into your contract. The MSAs listed on this site are examples of a “state purchasing
+    schedule.” These schedules are agreements between a state or related entity and vendor(s) to provide goods or services at
+    agreed-upon prices. Fundamentally, state purchasing schedules are designed to accommodate other parties that may enter into
+    and benefit from the agreements in the future. You’ll sign a contract with the vendors directly. However, the terms and
+    conditions (and pricing!) from the MSA are incorporated by reference in the contract that you will sign. You can use a
     California STD-213 or another DGS approved user agreement or equivalent. Please reach out to your desired acquirer directly
     for payment processing services.
   </p>


### PR DESCRIPTION
Per Q/A discussion, slight adjustment to the MSA section of the Tap to Pay page:
* Remove "Assess Vendor" heading
* Move up MSA link language
* Adjust headings and paragraph sizing accordingly. 

This is a post launch item. 