### PR TITLE
fix: ensure VS code customizations are loaded

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,21 +8,23 @@
   },
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   "customizations": {
-    "settings": {
-      "terminal.integrated.defaultProfile.linux": "bash",
-      "terminal.integrated.profiles.linux": {
-        "bash": {
-          "path": "/bin/bash"
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
         }
-      }
-    },
-    "extensions": [
-      "bungcip.better-toml",
-      "eamodio.gitlens",
-      "esbenp.prettier-vscode",
-      "mhutchie.git-graph",
-      "redhat.vscode-xml",
-      "sissel.shopify-liquid"
-    ]
+      },
+      "extensions": [
+        "bungcip.better-toml",
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "mhutchie.git-graph",
+        "redhat.vscode-xml",
+        "sissel.shopify-liquid"
+      ]
+    }
   }
 }


### PR DESCRIPTION
in #822 i missed the `"vscode"` key that ensures that extensions and other customizations are loaded correctly when building the container. 🤦‍♂️ 