### PR TITLE
fix: correct typo in broken redirect url

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -14,4 +14,4 @@
 /intro-gtfs-rt                                                      /gtfs-intro
 /provider-map                                                       /
 /resources/                                                         /tap-to-pay
-/uploads/MSA-SOW-Template-and-Guidance-2025.01.20.docx              /uploads/Cal-ITP.GTFS.RT.MSA.SOW.Template.and.Guidance.docx
+/uploads/MSA-SOW-Template-and-Guidance-2025.01.20.docx              /uploads/resources/Cal-ITP.GTFS.RT.MSA.SOW.Template.and.Guidance.docx


### PR DESCRIPTION
closes #828 by ensuring that the url below resolves:

https://deploy-preview-827--cal-itp-mobility-marketplace.netlify.app/uploads/MSA-SOW-Template-and-Guidance-2025.01.20.docx