### PR TITLE
fix: ensure powerpoints and spreadsheets are passthrough copied

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -16,6 +16,8 @@ export default async function (eleventyConfig) {
 
   eleventyConfig.addPassthroughCopy("src/uploads/**/*.pdf");
   eleventyConfig.addPassthroughCopy("src/uploads/resources/*.docx");
+  eleventyConfig.addPassthroughCopy("src/uploads/resources/*.pptx");
+  eleventyConfig.addPassthroughCopy("src/uploads/resources/*.xlsx");
   eleventyConfig.addPassthroughCopy("src/uploads/resources/*.zip");
 
   eleventyConfig.addPlugin(sitemap, { sitemap: { hostname: site.url } });

--- a/src/_layouts/doc-preview.html
+++ b/src/_layouts/doc-preview.html
@@ -19,6 +19,22 @@ layout: latest
         <h1 class="mt-2 mb-lg-3 text-start">{{ resource.title }}</h1>
         <a class="dl-button my-3 my-lg-4" href="{{resource.filename}}" download>Download</a>
         <p>{{ description }}</p>
+        {% comment %}
+          see code comment in msa-cost-estimation-tool.md
+        {% endcomment %}
+        {% if page.fileSlug == 'msa-cost-estimation-tool' %}
+          <p>
+            An Excel workbook intended for when an agency is ready to start creating cost estimates for purchasing tap to pay
+            hardware and software. You can use this workbook to compare MSA-awarded vendors’ maximum prices and develop ballpark
+            estimates for budgeting purposes (and board presentations), and make scoping decisions as you prepare to email vendors
+            during the vendor engagement phase.
+          </p>
+          <p>
+            <b class="text-body-xl">Note:</b> The prices in this workbook are maximums. Transit agencies are strongly encouraged
+            to reach out to vendors directly for tailored pricing. Prices may be reduced and/or fee categories waived, at vendors’
+            sole discretion.
+          </p>
+        {% endif %}
         <p class="mt-2 mt-lg-5">Last updated: {{ resource.lastUpdated | date: '%B %e, %Y' }} | Cal-ITP</p>
       </div>
       <div class="dl-hero-image col-12 col-lg-5 offset-lg-2">

--- a/src/resources/msa-cost-estimation-tool.md
+++ b/src/resources/msa-cost-estimation-tool.md
@@ -1,12 +1,18 @@
 ---
 layout: doc-preview
-description: >
-  An Excel workbook intended for when an agency is ready to start creating cost estimates for purchasing tap to pay hardware and software. You can use this workbook to compare MSA-awarded vendors’ maximum prices and develop ballpark estimates for budgeting purposes (and board presentations), and make scoping decisions as you prepare to email vendors during the vendor engagement phase.
-  <br>
-  <br>
-  <b class="text-body-xl">Note:</b> The prices in this workbook are maximums. Transit agencies are strongly encouraged to reach out to vendors directly for tailored pricing. Prices may be reduced and/or fee categories waived, at vendors’ sole discretion.
 ---
 
 {% comment %}
 page filename has to match a slug in resources.yml
+
+right now this is the only resource that doesn't supply a description via front-matter
+the template instead conditionally injects its own HTML. this is a code smell!
+
+TODO: either simplify this text so that we no longer need to inject HTML or figure out a way to pass it through 👇 from this page safely.
+
+An Excel workbook intended for when an agency is ready to start creating cost estimates for purchasing tap to pay hardware and software. You can use this workbook to compare MSA-awarded vendors’ maximum prices and develop ballpark estimates for budgeting purposes (and board presentations), and make scoping decisions as you prepare to email vendors during the vendor engagement phase.
+<br>
+<br>
+<b class="text-body-xl">Note:</b> The prices in this workbook are maximums. Transit agencies are strongly encouraged to reach out to vendors directly for tailored pricing. Prices may be reduced and/or fee categories waived, at vendors’ sole discretion.
+
 {% endcomment %}


### PR DESCRIPTION
resolves https://cal-itp.slack.com/archives/C018XMWT2FN/p1771453380429109

this one was my mistake, when we migrated to 11ty i forgot to triple-check all the individual file extensions that we now need to whitelist.

while i was in here i noticed the description HTML we're trying to inject on the MSA Cost Estimation Tool preview page specifically results in some visual jank.

<img width="1468" height="208" alt="Screenshot 2026-02-18 at 2 53 34 PM" src="https://github.com/user-attachments/assets/61b5b636-32fd-4874-a1e1-034360f4ae65" />

i pushed a commit with a stopgap fix for that too. i'll leave it for @machikoyasuda to think through something saner at her leisure.

* https://deploy-preview-835--cal-itp-mobility-marketplace.netlify.app/resources/msa-cost-estimation-tool/
* https://deploy-preview-835--cal-itp-mobility-marketplace.netlify.app/resources/contactless-payments-support-framework/