### PR TITLE
Fix: Show 404 custom layout on 404

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -2,6 +2,7 @@
 layout: latest
 title: Page Not Found
 eleventyExcludeFromCollections: true
+permalink: 404.html
 ---
 
 <div class="container-sm">


### PR DESCRIPTION
closes #839 

<img width="1512" height="867" alt="image" src="https://github.com/user-attachments/assets/f3f7bc9b-c4f9-44f0-ae5e-c3d15fdf4dd0" />

## How to test
1. https://deploy-preview-840--cal-itp-mobility-marketplace.netlify.app/asdfsdf