### PR TITLE
Fix: Remove MSA Cost Estimation tool description funkiness

### DIFF
--- a/src/_layouts/doc-preview.html
+++ b/src/_layouts/doc-preview.html
@@ -20,22 +20,6 @@ stylesheet: doc-preview.css
         <h1 class="mt-2 mb-lg-3 text-start">{{ resource.title }}</h1>
         <a class="dl-button my-3 my-lg-4" href="{{resource.filename}}" download>Download</a>
         <p>{{ description }}</p>
-        {% comment %}
-          see code comment in msa-cost-estimation-tool.md
-        {% endcomment %}
-        {% if page.fileSlug == 'msa-cost-estimation-tool' %}
-          <p>
-            An Excel workbook intended for when an agency is ready to start creating cost estimates for purchasing tap to pay
-            hardware and software. You can use this workbook to compare MSA-awarded vendors’ maximum prices and develop ballpark
-            estimates for budgeting purposes (and board presentations), and make scoping decisions as you prepare to email vendors
-            during the vendor engagement phase.
-          </p>
-          <p>
-            <b class="text-body-xl">Note:</b> The prices in this workbook are maximums. Transit agencies are strongly encouraged
-            to reach out to vendors directly for tailored pricing. Prices may be reduced and/or fee categories waived, at vendors’
-            sole discretion.
-          </p>
-        {% endif %}
         <p class="mt-2 mt-lg-5">Last updated: {{ resource.lastUpdated | date: '%B %e, %Y' }} | Cal-ITP</p>
       </div>
       <div class="dl-hero-image col-12 col-lg-5 offset-lg-2">

--- a/src/resources/msa-cost-estimation-tool.md
+++ b/src/resources/msa-cost-estimation-tool.md
@@ -9,4 +9,4 @@ description: >
 
 {% comment %}
 page filename has to match a slug in resources.yml
-{% comment}
+{% endcomment %}

--- a/src/resources/msa-cost-estimation-tool.md
+++ b/src/resources/msa-cost-estimation-tool.md
@@ -1,18 +1,8 @@
 ---
 layout: doc-preview
+description: >
+  An Excel workbook intended for when an agency is ready to start creating cost estimates for purchasing tap to pay hardware and software. You can use this workbook to compare MSA-awarded vendors’ maximum prices and develop ballpark estimates for budgeting purposes (and board presentations), and make scoping decisions as you prepare to email vendors during the vendor engagement phase.
+  <br>
+  <br>
+  <b>Note:</b> The prices in this workbook are maximums. Transit agencies are strongly encouraged to reach out to vendors directly for tailored pricing. Prices may be reduced and/or fee categories waived, at vendors’ sole discretion.
 ---
-
-{% comment %}
-page filename has to match a slug in resources.yml
-
-right now this is the only resource that doesn't supply a description via front-matter
-the template instead conditionally injects its own HTML. this is a code smell!
-
-TODO: either simplify this text so that we no longer need to inject HTML or figure out a way to pass it through 👇 from this page safely.
-
-An Excel workbook intended for when an agency is ready to start creating cost estimates for purchasing tap to pay hardware and software. You can use this workbook to compare MSA-awarded vendors’ maximum prices and develop ballpark estimates for budgeting purposes (and board presentations), and make scoping decisions as you prepare to email vendors during the vendor engagement phase.
-<br>
-<br>
-<b class="text-body-xl">Note:</b> The prices in this workbook are maximums. Transit agencies are strongly encouraged to reach out to vendors directly for tailored pricing. Prices may be reduced and/or fee categories waived, at vendors’ sole discretion.
-
-{% endcomment %}

--- a/src/resources/msa-cost-estimation-tool.md
+++ b/src/resources/msa-cost-estimation-tool.md
@@ -6,3 +6,7 @@ description: >
   <br>
   <b>Note:</b> The prices in this workbook are maximums. Transit agencies are strongly encouraged to reach out to vendors directly for tailored pricing. Prices may be reduced and/or fee categories waived, at vendors’ sole discretion.
 ---
+
+{% comment %}
+page filename has to match a slug in resources.yml
+{% comment}


### PR DESCRIPTION
closes #836 

<img width="1374" height="812" alt="image" src="https://github.com/user-attachments/assets/caa40597-bb07-47a2-993a-76743d1996e0" />

No more one-off logic in the layout.