### PR TITLE
Tell Dependabot to check Node packages instead of Ruby gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of Gemfile
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
Something we overlooked in the switch from Jekyll to 11ty.