### PR TITLE
chore: update github action code comment to match current implementation

### DIFF
--- a/.github/workflows/add-to-project-issues.yml
+++ b/.github/workflows/add-to-project-issues.yml
@@ -1,4 +1,4 @@
-# Add secret GH_PROJECT (the Project's ID) and allow org-wide secret GH_PROJECTS_TOKEN to the repo
+# assumes org-wide USB_PROJECT_URL and USB_PROJECT_TOKEN secrets are accessible to the repo.
 
 name: Add Issues to Project
 


### PR DESCRIPTION
this is just a drive-by fix to ensure that the name of the secrets in a github action code comment are the same as the secrets that are actually referenced in the code.

see https://github.com/cal-itp/.github/issues/2 for more info