### PR TITLE
feat(homepage): Make logo strip pauseable

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -37,13 +37,13 @@ stylesheet: homepage.css
         </svg>
         <svg
           class="play-icon d-none"
-          width="18"
-          height="16"
-          viewBox="0 0 18 16"
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
           fill="currentcolor"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <polygon points="3.5,0 3.5,16 17.36,8" rx="2" />
+          <path d="M18.5 9.13398C19.1667 9.51888 19.1667 10.4811 18.5 10.866L6.5 17.7942C5.83333 18.1791 5 17.698 5 16.9282L5 3.0718C5 2.302 5.83333 1.82088 6.5 2.20578L18.5 9.13398Z" />
         </svg>
       </button>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,27 @@ stylesheet: homepage.css
 </section>
 
 <section class="logo-strip">
-  <h2 class="visually-hidden">Transit providers that have worked with Cal-ITP</h2>
+  <div class="container-sm mb-4">
+    <div class="d-flex gap-3 align-items-center justify-content-center justify-content-lg-start offset-lg-1">
+      <h2 class="h4 lh-1 fw-normal mb-0">Agencies we work with</h2>
+      <button class="logo-strip-pause-btn d-flex align-items-center justify-content-center" id="logo-strip-pause-btn">
+        <svg class="pause-icon" width="12" height="16" viewBox="0 0 12 16" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+          <rect width="4" height="16" rx="2" />
+          <rect x="8" width="4" height="16" rx="2" />
+        </svg>
+        <svg
+          class="play-icon d-none"
+          width="18"
+          height="16"
+          viewBox="0 0 18 16"
+          fill="currentcolor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polygon points="3.5,0 3.5,16 17.36,8" rx="2" />
+        </svg>
+      </button>
+    </div>
+  </div>
   <ul class="logo-strip-list">
     {% for agency in agencies -%}
       <li><img src="/uploads/{{ agency.logo }}" alt="{{ agency.name }}"></li>
@@ -263,3 +283,15 @@ stylesheet: homepage.css
     <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">hello@calitp.org</a>.
   </p>
 </section>
+
+<script>
+  const logoStripPauseButton = document.querySelector('.logo-strip-pause-btn');
+  const logoStripList = document.querySelector('.logo-strip-list');
+  const pauseIcon = document.querySelector('.pause-icon');
+  const playIcon = document.querySelector('.play-icon');
+  logoStripPauseButton.addEventListener('click', (e) => {
+    logoStripList.toggleAttribute('data-paused');
+    pauseIcon.classList.toggle('d-none');
+    playIcon.classList.toggle('d-none');
+  });
+</script>

--- a/src/index.html
+++ b/src/index.html
@@ -30,21 +30,24 @@ stylesheet: homepage.css
   <div class="container-sm mb-4">
     <div class="d-flex gap-3 align-items-center justify-content-center justify-content-lg-start offset-lg-1">
       <h2 class="h4 lh-1 fw-normal mb-0">Agencies we work with</h2>
-      <button class="logo-strip-pause-btn d-flex align-items-center justify-content-center" id="logo-strip-pause-btn">
+      <button class="logo-strip-pause-btn align-items-center justify-content-center" role="switch" aria-checked="true" hidden>
         <svg class="pause-icon" width="12" height="16" viewBox="0 0 12 16" fill="currentcolor" xmlns="http://www.w3.org/2000/svg">
+          <title>Pause icon</title>
           <rect width="4" height="16" rx="2" />
           <rect x="8" width="4" height="16" rx="2" />
         </svg>
         <svg
-          class="play-icon d-none"
+          class="play-icon"
           width="20"
           height="20"
           viewBox="0 0 20 20"
           fill="currentcolor"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title>Resume icon</title>
           <path d="M18.5 9.13398C19.1667 9.51888 19.1667 10.4811 18.5 10.866L6.5 17.7942C5.83333 18.1791 5 17.698 5 16.9282L5 3.0718C5 2.302 5.83333 1.82088 6.5 2.20578L18.5 9.13398Z" />
         </svg>
+        <span class="screen-reader-text visually-hidden">Toggle animation</span>
       </button>
     </div>
   </div>
@@ -286,12 +289,35 @@ stylesheet: homepage.css
 
 <script>
   const logoStripPauseButton = document.querySelector('.logo-strip-pause-btn');
+
+  // Button is hidden unless JavaScript is enabled, so unhide it if this runs:
+  logoStripPauseButton.hidden = false;
+  logoStripPauseButton.classList.add('d-flex');
+
+  // If user has prefers-reduced-motion set, change initial state to paused
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    logoStripPauseButton.setAttribute('aria-checked', 'false');
+  }
+
   const logoStripList = document.querySelector('.logo-strip-list');
   const pauseIcon = document.querySelector('.pause-icon');
   const playIcon = document.querySelector('.play-icon');
+  const screenReaderText = document.querySelector('.screen-reader-text');
+
   logoStripPauseButton.addEventListener('click', (e) => {
-    logoStripList.toggleAttribute('data-paused');
-    pauseIcon.classList.toggle('d-none');
-    playIcon.classList.toggle('d-none');
+    // Check current state of the switch and toggle things accordingly
+    if (logoStripPauseButton.getAttribute('aria-checked') === 'true') {
+      // We have just paused
+      pauseIcon.style.setProperty('display', 'none');
+      playIcon.style.setProperty('display', 'block');
+      logoStripList.style.setProperty('--playState', 'paused');
+      logoStripPauseButton.setAttribute('aria-checked', 'false');
+    } else {
+      // We have just resumed
+      pauseIcon.style.setProperty('display', 'block');
+      playIcon.style.setProperty('display', 'none');
+      logoStripList.style.setProperty('--playState', 'running');
+      logoStripPauseButton.setAttribute('aria-checked', 'true');
+    }
   });
 </script>

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -3,13 +3,14 @@
 /* HOMEPAGE */
 
 .logo-strip {
-  padding-bottom: 48px;
+  padding-bottom: 48px; /* matches the height of the logo images themselves */
   margin-bottom: var(--spacing-8);
   position: relative;
 }
 .logo-strip-pause-btn {
   width: calc(var(--spacing-base) * 4.25); /* 2.125rem (34px) */
   height: calc(var(--spacing-base) * 4.25); /* 2.125rem (34px) */
+  padding: 0;
   border-width: 1px;
   border-style: solid;
   border-color: var(--dsdl-cyan-50);

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -3,10 +3,20 @@
 /* HOMEPAGE */
 
 .logo-strip {
-  height: 48px;
+  padding-bottom: 48px;
   margin-bottom: var(--spacing-8);
   position: relative;
   overflow: hidden;
+}
+.logo-strip-pause-btn {
+  width: var(--spacing-4);
+  height: var(--spacing-4);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--dsdl-cyan-50);
+  border-radius: var(--button-border-radius);
+  background-color: transparent;
+  color: var(--dsdl-cyan-50);
 }
 .logo-strip-list {
   list-style: none;
@@ -25,6 +35,9 @@
 }
 .logo-strip img {
   height: 100%;
+}
+.logo-strip-list[data-paused] {
+  animation-play-state: paused;
 }
 
 @keyframes slide-to-the-left {

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -6,17 +6,19 @@
   padding-bottom: 48px;
   margin-bottom: var(--spacing-8);
   position: relative;
-  overflow: hidden;
 }
 .logo-strip-pause-btn {
-  width: var(--spacing-4);
-  height: var(--spacing-4);
+  width: calc(var(--spacing-base) * 4.25); /* 2.125rem (34px) */
+  height: calc(var(--spacing-base) * 4.25); /* 2.125rem (34px) */
   border-width: 1px;
   border-style: solid;
   border-color: var(--dsdl-cyan-50);
   border-radius: var(--button-border-radius);
   background-color: transparent;
   color: var(--dsdl-cyan-50);
+}
+.pause-icon {
+  display: none;
 }
 .logo-strip-list {
   list-style: none;
@@ -28,6 +30,7 @@
   animation-duration: 120s;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
+  animation-play-state: var(--playState, paused);
 }
 .logo-strip-list > li {
   height: 48px;
@@ -36,8 +39,17 @@
 .logo-strip img {
   height: 100%;
 }
-.logo-strip-list[data-paused] {
-  animation-play-state: paused;
+
+@media (prefers-reduced-motion: no-preference) {
+  .pause-icon {
+    display: block;
+  }
+  .play-icon {
+    display: none;
+  }
+  .logo-strip-list {
+    --playState: running;
+  }
 }
 
 @keyframes slide-to-the-left {


### PR DESCRIPTION
Closes #855 

---

- Adds a button to pause the animation of the logo strip on the homepage
- Adds a visible "Agencies we work with" heading

<img width="566" height="315" alt="CleanShot 2026-03-25 at 12 51 40@2x" src="https://github.com/user-attachments/assets/891eadfa-5aae-43d4-a6e0-80d15ab02953" />
