### PR TITLE
fix: Eliminate horizontal scrollbar caused by logo-strip overflow

### DIFF
--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -3,6 +3,8 @@
 /* HOMEPAGE */
 
 .logo-strip {
+  overflow: hidden; /* prevent logo strip from causing horizontal scroll */
+  padding-top: 2px; /* keep top of pause button's focus outline visible despite overflow: hidden */
   padding-bottom: 48px; /* matches the height of the logo images themselves */
   margin-bottom: var(--spacing-8);
   position: relative;


### PR DESCRIPTION
Addressing regression @cmajel noted in https://github.com/cal-itp/mobility-marketplace/pull/862#issuecomment-4138328351.