### PR TITLE
Improve table responsiveness on small screens

### DIFF
--- a/src/data-plans.html
+++ b/src/data-plans.html
@@ -103,7 +103,7 @@ connectivity to modernize and improve the rider experience.' %}
   <h4 id="contracts" class="mt-3">Data plans MSAs</h4>
   <p>Cost per month per vehicle, prices are negotiable</p>
   <div class="table-responsive my-3">
-    <table class="table_purple mb-1">
+    <table class="table_purple mb-2">
       <thead>
         <tr>
           <th scope="row">MSAs</th>

--- a/src/data-plans.html
+++ b/src/data-plans.html
@@ -171,9 +171,6 @@ connectivity to modernize and improve the rider experience.' %}
           <td>–</td>
         </tr>
       </tbody>
-      <caption class="visually-hidden">
-        Data plans MSAs (cost per month per vehicle, prices are negotiable, click on each MSA for terms and conditions)
-      </caption>
     </table>
   </div>
   <p class="table-caption">Click on each MSA for terms and conditions.</p>

--- a/src/data-plans.html
+++ b/src/data-plans.html
@@ -102,78 +102,80 @@ connectivity to modernize and improve the rider experience.' %}
   </p>
   <h4 id="contracts" class="mt-3">Data plans MSAs</h4>
   <p>Cost per month per vehicle, prices are negotiable</p>
-  <table class="table_purple my-3">
-    <thead>
-      <tr>
-        <th scope="row">MSAs</th>
-        <th colspan="3" scope="col">
-          <a href="https://cdt.ca.gov/services/calnet-calitp/">CALNET</a> +
-          <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
-            >NASPO</a
-          >
-        </th>
-        <th scope="col">
-          <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
-            >NASPO</a
-          >
-        </th>
-      </tr>
-      <tr>
-        <th scope="row">Vendors</th>
-        <th scope="col">AT&T</th>
-        <th scope="col" class="text-nowrap">T-Mobile</th>
-        <th scope="col">Verizon</th>
-        <th scope="col">FirstNet</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th scope="row">1 GB</th>
-        <td>$20</td>
-        <td>$8</td>
-        <td>$15</td>
-        <td>$7.50</td>
-      </tr>
-      <tr>
-        <th scope="row">2 GB</th>
-        <td>$23</td>
-        <td>$10</td>
-        <td>$20</td>
-        <td>–</td>
-      </tr>
-      <tr>
-        <th scope="row">3 GB</th>
-        <td>–</td>
-        <td>–</td>
-        <td>–</td>
-        <td>$20</td>
-      </tr>
-      <tr>
-        <th scope="row">5 GB</th>
-        <td>$28</td>
-        <td>$21.21</td>
-        <td>$25</td>
-        <td>–</td>
-      </tr>
-      <tr>
-        <th scope="row">25 GB</th>
-        <td>–</td>
-        <td>–</td>
-        <td>–</td>
-        <td>$34</td>
-      </tr>
-      <tr>
-        <th scope="row">Unlimited</th>
-        <td>$50</td>
-        <td>–</td>
-        <td>$34.99</td>
-        <td>–</td>
-      </tr>
-    </tbody>
-    <caption class="visually-hidden">
-      Data plans MSAs (cost per month per vehicle, prices are negotiable, click on each MSA for terms and conditions)
-    </caption>
-  </table>
+  <div class="table-responsive my-3">
+    <table class="table_purple mb-1">
+      <thead>
+        <tr>
+          <th scope="row">MSAs</th>
+          <th colspan="3" scope="col">
+            <a href="https://cdt.ca.gov/services/calnet-calitp/">CALNET</a> +
+            <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
+              >NASPO</a
+            >
+          </th>
+          <th scope="col">
+            <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
+              >NASPO</a
+            >
+          </th>
+        </tr>
+        <tr>
+          <th scope="row">Vendors</th>
+          <th scope="col">AT&T</th>
+          <th scope="col" class="text-nowrap">T-Mobile</th>
+          <th scope="col">Verizon</th>
+          <th scope="col">FirstNet</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1 GB</th>
+          <td>$20</td>
+          <td>$8</td>
+          <td>$15</td>
+          <td>$7.50</td>
+        </tr>
+        <tr>
+          <th scope="row">2 GB</th>
+          <td>$23</td>
+          <td>$10</td>
+          <td>$20</td>
+          <td>–</td>
+        </tr>
+        <tr>
+          <th scope="row">3 GB</th>
+          <td>–</td>
+          <td>–</td>
+          <td>–</td>
+          <td>$20</td>
+        </tr>
+        <tr>
+          <th scope="row">5 GB</th>
+          <td>$28</td>
+          <td>$21.21</td>
+          <td>$25</td>
+          <td>–</td>
+        </tr>
+        <tr>
+          <th scope="row">25 GB</th>
+          <td>–</td>
+          <td>–</td>
+          <td>–</td>
+          <td>$34</td>
+        </tr>
+        <tr>
+          <th scope="row">Unlimited</th>
+          <td>$50</td>
+          <td>–</td>
+          <td>$34.99</td>
+          <td>–</td>
+        </tr>
+      </tbody>
+      <caption class="visually-hidden">
+        Data plans MSAs (cost per month per vehicle, prices are negotiable, click on each MSA for terms and conditions)
+      </caption>
+    </table>
+  </div>
   <p class="table-caption">Click on each MSA for terms and conditions.</p>
   <h3 class="numbered numbered_purple" data-number="3">Reach out to your vendor</h3>
   <p>Reach out to the vendor you’d like to work with. Share your agency goals, hardware, and desired data plan.</p>

--- a/src/demo.html
+++ b/src/demo.html
@@ -180,9 +180,6 @@ show_call_to_action: true
         </td>
       </tr>
     </tbody>
-    <caption class="visually-hidden">
-      Payment Processors MSAs (click on each MSA for terms and conditions)
-    </caption>
   </table>
   <h3>Responsive, color scheme: purple</h3>
   <div class="table-responsive my-3">
@@ -254,9 +251,6 @@ show_call_to_action: true
           <td>–</td>
         </tr>
       </tbody>
-      <caption class="visually-hidden">
-        Data plans MSAs (cost per month per vehicle, prices are negotiable, click on each MSA for terms and conditions)
-      </caption>
     </table>
   </div>
   <h3>Responsive, color scheme: cyan</h3>
@@ -350,9 +344,6 @@ show_call_to_action: true
           </td>
         </tr>
       </tbody>
-      <caption class="visually-hidden">
-        GTFS Realtime MSAs (click on each MSA for terms and conditions)
-      </caption>
     </table>
   </div>
 </div>

--- a/src/demo.html
+++ b/src/demo.html
@@ -1,5 +1,6 @@
 ---
 layout: main
+stylesheet: guide.css
 
 title: Component demo
 description: >
@@ -137,238 +138,222 @@ show_call_to_action: true
     </div>
   </div>
 
-  <div class="row">
-    <h2>Tables</h2>
-    <div class="offset-lg-2 col-lg-7 col-12 table-responsive">
-      <h3>Color scheme: yellow</h3>
-      <table class="table_yellow my-4">
-        <thead>
-          <tr>
-            <th scope="col">Vendors</th>
-            <th scope="col">MSAs</th>
-            <th scope="col">Types of transactions</th>
-            <th scope="col">Payment networks</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Fiserv*</td>
-            <td>
-              <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-22-70-22-02&SETID=STATE&VERSION_NBR=2"
-                >5-22-70-22-02</a
-              >
-            </td>
-            <td>
-              <ul>
-                <li>credit</li>
-                <li>debit</li>
-                <li>mobile wallet</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>American Express</li>
-                <li>Discover</li>
-                <li>Mastercard</li>
-                <li>Visa</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>Elavon*</td>
-            <td>
-              <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-22-70-22-01&SETID=STATE&VERSION_NBR=3"
-                >5-22-70-22-01</a
-              >
-            </td>
-            <td>
-              <ul>
-                <li>credit</li>
-                <li>debit</li>
-                <li>mobile wallet</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>American Express</li>
-                <li>Discover</li>
-                <li>Mastercard</li>
-                <li>Visa</li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-        <caption class="visually-hidden">
-          Payment Processors MSAs (click on each MSA for terms and conditions)
-        </caption>
-      </table>
-      <h3>Color scheme: purple</h3>
-      <table class="table_purple my-4">
-        <thead>
-          <tr>
-            <th scope="row">MSAs</th>
-            <th colspan="3" scope="col">
-              <a href="https://cdt.ca.gov/services/calnet-calitp/">CALNET</a> +
-              <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
-                >NASPO</a
-              >
-            </th>
-            <th scope="col">
-              <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
-                >NASPO</a
-              >
-            </th>
-          </tr>
-          <tr>
-            <th scope="row">Vendors</th>
-            <th scope="col">AT&T</th>
-            <th scope="col" class="text-nowrap">T-Mobile</th>
-            <th scope="col">Verizon</th>
-            <th scope="col">FirstNet</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">1 GB</th>
-            <td>$20</td>
-            <td>$8</td>
-            <td>$15</td>
-            <td>$7.50</td>
-          </tr>
-          <tr>
-            <th scope="row">2 GB</th>
-            <td>$23</td>
-            <td>$10</td>
-            <td>$20</td>
-            <td>–</td>
-          </tr>
-          <tr>
-            <th scope="row">3 GB</th>
-            <td>–</td>
-            <td>–</td>
-            <td>–</td>
-            <td>$20</td>
-          </tr>
-          <tr>
-            <th scope="row">5 GB</th>
-            <td>$28</td>
-            <td>$21.21</td>
-            <td>$25</td>
-            <td>–</td>
-          </tr>
-          <tr>
-            <th scope="row">25 GB</th>
-            <td>–</td>
-            <td>–</td>
-            <td>–</td>
-            <td>$34</td>
-          </tr>
-          <tr>
-            <th scope="row">Unlimited</th>
-            <td>$50</td>
-            <td>–</td>
-            <td>$34.99</td>
-            <td>–</td>
-          </tr>
-        </tbody>
-        <caption class="visually-hidden">
-          Data plans MSAs (cost per month per vehicle, prices are negotiable, click on each MSA for terms and conditions)
-        </caption>
-      </table>
-      <h3>Color scheme: cyan</h3>
-      <p><i>Note:</i> There is only one cyan color scheme for tables, not both light and dark cyan.</p>
-      <table class="table_cyan wider my-4">
-        <thead>
-          <tr>
-            <th scope="col">MSA vendors</th>
-            <th scope="col">MSAs</th>
-            <th scope="col">Pricing structure</th>
-            <th scope="col">Hardware options</th>
-            <th scope="col">Eligible networks</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Connexionz Ltd</td>
-            <td>
-              <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3"
-                >5-24-70-42-01</a
-              >
-            </td>
-            <td>Base fee + variable fees based on EITHER vehicles or routes</td>
-            <td>Cellular routing kit (with Pepwave MAX BR1 Mini)</td>
-            <td>
-              <ul>
-                <li>WiFi</li>
-                <li>AT&T</li>
-                <li class="text-nowrap">T-Mobile</li>
-                <li>Verizon</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>Passio Technologies LLC</td>
-            <td>
-              <a href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02"
-                >5-24-70-42-02</a
-              >
-            </td>
-            <td>Base fee + variable fees based on EITHER vehicles or routes</td>
-            <td>
-              <ul>
-                <li>Calamp LMU-3641</li>
-                <li>Lilliput RT-V7000 Pro</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>WiFi</li>
-                <li>AT&T</li>
-                <li class="text-nowrap">T-Mobile</li>
-                <li>Verizon</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td rowspan="2" style="border-bottom: none;">Swiftly Inc</td>
-            <td rowspan="2" style="border-bottom: none;">
-              <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2"
-                >5-24-70-42-03</a
-              >
-            </td>
-            <td rowspan="2" style="border-bottom: none;">Variable fees based on number of vehicles</td>
-            <td>Samsara VG55</td>
-            <td>
-              <ul>
-                <li>WiFi</li>
-                <li>AT&T</li>
-                <li>FirstNet</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul>
-                <li>Samsung Tab Active 5</li>
-                <li>Cradlepoint R1900</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>WiFi</li>
-                <li>AT&T</li>
-                <li>FirstNet</li>
-                <li>T-Mobile</li>
-                <li>Verizon</li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-        <caption class="visually-hidden">
-          GTFS Realtime MSAs (click on each MSA for terms and conditions)
-        </caption>
-      </table>
-    </div>
+  <h2>Tables</h2>
+  <h3>Not responsive, color scheme: yellow</h3>
+  <table class="table_yellow my-3">
+    <thead>
+      <tr>
+        <th scope="col">Vendors</th>
+        <th scope="col">MSAs</th>
+        <th scope="col">Types of transactions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>Fiserv*</th>
+        <td>
+          <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-22-70-22-02&SETID=STATE&VERSION_NBR=2"
+            >5-22-70-22-02</a
+          >
+        </td>
+        <td>
+          <ul>
+            <li>credit</li>
+            <li>debit</li>
+            <li>mobile wallet</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th>Elavon*</th>
+        <td>
+          <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-22-70-22-01&SETID=STATE&VERSION_NBR=3"
+            >5-22-70-22-01</a
+          >
+        </td>
+        <td>
+          <ul>
+            <li>credit</li>
+            <li>debit</li>
+            <li>mobile wallet</li>
+          </ul>
+        </td>
+      </tr>
+    </tbody>
+    <caption class="visually-hidden">
+      Payment Processors MSAs (click on each MSA for terms and conditions)
+    </caption>
+  </table>
+  <h3>Responsive, color scheme: purple</h3>
+  <div class="table-responsive my-3">
+    <table class="table_purple mb-2">
+      <thead>
+        <tr>
+          <th scope="row">MSAs</th>
+          <th colspan="3" scope="col">
+            <a href="https://cdt.ca.gov/services/calnet-calitp/">CALNET</a> +
+            <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
+              >NASPO</a
+            >
+          </th>
+          <th scope="col">
+            <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
+              >NASPO</a
+            >
+          </th>
+        </tr>
+        <tr>
+          <th scope="row">Vendors</th>
+          <th scope="col">AT&T</th>
+          <th scope="col" class="text-nowrap">T-Mobile</th>
+          <th scope="col">Verizon</th>
+          <th scope="col">FirstNet</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1 GB</th>
+          <td>$20</td>
+          <td>$8</td>
+          <td>$15</td>
+          <td>$7.50</td>
+        </tr>
+        <tr>
+          <th scope="row">2 GB</th>
+          <td>$23</td>
+          <td>$10</td>
+          <td>$20</td>
+          <td>–</td>
+        </tr>
+        <tr>
+          <th scope="row">3 GB</th>
+          <td>–</td>
+          <td>–</td>
+          <td>–</td>
+          <td>$20</td>
+        </tr>
+        <tr>
+          <th scope="row">5 GB</th>
+          <td>$28</td>
+          <td>$21.21</td>
+          <td>$25</td>
+          <td>–</td>
+        </tr>
+        <tr>
+          <th scope="row">25 GB</th>
+          <td>–</td>
+          <td>–</td>
+          <td>–</td>
+          <td>$34</td>
+        </tr>
+        <tr>
+          <th scope="row">Unlimited</th>
+          <td>$50</td>
+          <td>–</td>
+          <td>$34.99</td>
+          <td>–</td>
+        </tr>
+      </tbody>
+      <caption class="visually-hidden">
+        Data plans MSAs (cost per month per vehicle, prices are negotiable, click on each MSA for terms and conditions)
+      </caption>
+    </table>
+  </div>
+  <h3>Responsive, color scheme: cyan</h3>
+  <p><i>Note:</i> There is only one cyan color scheme for tables, not both light and dark cyan.</p>
+  <div class="table-responsive my-3">
+    <table class="table_cyan mb-2">
+      <thead>
+        <tr>
+          <th scope="col">MSA vendors</th>
+          <th scope="col">MSAs</th>
+          <th scope="col">Pricing structure</th>
+          <th scope="col">Hardware options</th>
+          <th scope="col">Eligible networks</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>Connexionz Ltd</th>
+          <td>
+            <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3"
+              >5-24-70-42-01</a
+            >
+          </td>
+          <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+          <td>Cellular routing kit (with Pepwave MAX BR1 Mini)</td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li class="text-nowrap">T-Mobile</li>
+              <li>Verizon</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th>Passio Technologies LLC</th>
+          <td>
+            <a href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02"
+              >5-24-70-42-02</a
+            >
+          </td>
+          <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+          <td>
+            <ul>
+              <li>Calamp LMU-3641</li>
+              <li>Lilliput RT-V7000 Pro</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li class="text-nowrap">T-Mobile</li>
+              <li>Verizon</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th rowspan="2" style="border-bottom: none;">Swiftly Inc</th>
+          <td rowspan="2" style="border-bottom: none;">
+            <a href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2"
+              >5-24-70-42-03</a
+            >
+          </td>
+          <td rowspan="2" style="border-bottom: none;">Variable fees based on number of vehicles</td>
+          <td>Samsara VG55</td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li>FirstNet</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          {% comment %} part of above Swiftly row; classes compensate for sticky first cell styling {% endcomment %}
+          <td class="position-static border-start-0">
+            <ul>
+              <li>Samsung Tab Active 5</li>
+              <li>Cradlepoint R1900</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li>FirstNet</li>
+              <li>T-Mobile</li>
+              <li>Verizon</li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+      <caption class="visually-hidden">
+        GTFS Realtime MSAs (click on each MSA for terms and conditions)
+      </caption>
+    </table>
   </div>
 </div>
 {% include 'downloadable-resources.html' resource_tag='GTFS-RT' %}
@@ -388,7 +373,7 @@ show_call_to_action: true
         <p class="mt-2 mt-lg-5">Last updated: November 2025 | Cal-ITP</p>
       </div>
       <div class="dl-hero-image col-12 col-lg-5 offset-lg-2">
-        <img src="https://placehold.co/544x704/white/black?text=8.5×11" alt="First page of the document">
+        <img class="w-100" src="https://placehold.co/544x704/white/black?text=8.5×11" alt="First page of the document">
       </div>
     </div>
   </div>

--- a/src/gtfs-realtime.html
+++ b/src/gtfs-realtime.html
@@ -103,7 +103,7 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
   <h4 id="contracts" class="mt-3">GTFS Realtime MSAs</h4>
   <p class="table-caption">Click on each MSA for terms and conditions.</p>
   <div class="table-responsive my-3">
-    <table class="table_cyan wider mb-1">
+    <table class="table_cyan mb-2">
       <thead>
         <tr>
           <th scope="col">MSA vendors</th>
@@ -115,7 +115,7 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
       </thead>
       <tbody>
         <tr>
-          <td>Connexionz Ltd</td>
+          <th>Connexionz Ltd</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3"
@@ -134,7 +134,7 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
           </td>
         </tr>
         <tr>
-          <td>Passio Technologies LLC</td>
+          <th>Passio Technologies LLC</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02"
@@ -158,7 +158,7 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
           </td>
         </tr>
         <tr>
-          <td rowspan="2" style="border-bottom: none">Swiftly Inc</td>
+          <th rowspan="2" style="border-bottom: none">Swiftly Inc</th>
           <td rowspan="2" style="border-bottom: none">
             <a
               href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2"
@@ -176,7 +176,8 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
           </td>
         </tr>
         <tr>
-          <td>
+          {% comment %} part of above Swiftly row; classes compensate for sticky first cell styling {% endcomment %}
+          <td class="position-static border-start-0">
             <ul>
               <li>Samsung Tab Active 5</li>
               <li>Cradlepoint R1900</li>

--- a/src/gtfs-realtime.html
+++ b/src/gtfs-realtime.html
@@ -194,9 +194,6 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
           </td>
         </tr>
       </tbody>
-      <caption class="visually-hidden">
-        GTFS Realtime MSAs (click on each MSA for terms and conditions)
-      </caption>
     </table>
   </div>
   <p class="table-caption">

--- a/src/gtfs-realtime.html
+++ b/src/gtfs-realtime.html
@@ -102,100 +102,102 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
   </p>
   <h4 id="contracts" class="mt-3">GTFS Realtime MSAs</h4>
   <p class="table-caption">Click on each MSA for terms and conditions.</p>
-  <table class="table_cyan wider my-3">
-    <thead>
-      <tr>
-        <th scope="col">MSA vendors</th>
-        <th scope="col">MSAs</th>
-        <th scope="col">Pricing structure</th>
-        <th scope="col">Hardware options**</th>
-        <th scope="col">Eligible networks</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Connexionz Ltd</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3"
-            >5-24-70-42-01</a
-          >
-        </td>
-        <td>Base fee + variable fees based on EITHER vehicles or routes</td>
-        <td>Cellular routing kit (with Pepwave MAX BR1 Mini)</td>
-        <td>
-          <ul>
-            <li>WiFi</li>
-            <li>AT&T</li>
-            <li class="text-nowrap">T-Mobile</li>
-            <li>Verizon</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>Passio Technologies LLC</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02"
-            >5-24-70-42-02</a
-          >
-        </td>
-        <td>Base fee + variable fees based on EITHER vehicles or routes</td>
-        <td>
-          <ul>
-            <li>Calamp LMU-3641</li>
-            <li>Lilliput RT-V7000 Pro</li>
-          </ul>
-        </td>
-        <td>
-          <ul>
-            <li>WiFi</li>
-            <li>AT&T</li>
-            <li class="text-nowrap">T-Mobile</li>
-            <li>Verizon</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td rowspan="2" style="border-bottom: none">Swiftly Inc</td>
-        <td rowspan="2" style="border-bottom: none">
-          <a
-            href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2"
-            >5-24-70-42-03</a
-          >
-        </td>
-        <td rowspan="2" style="border-bottom: none">Variable fees based on number of vehicles</td>
-        <td>Samsara VG55</td>
-        <td>
-          <ul>
-            <li>WiFi</li>
-            <li>AT&T</li>
-            <li>FirstNet</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <ul>
-            <li>Samsung Tab Active 5</li>
-            <li>Cradlepoint R1900</li>
-          </ul>
-        </td>
-        <td>
-          <ul>
-            <li>WiFi</li>
-            <li>AT&T</li>
-            <li>FirstNet</li>
-            <li>T-Mobile</li>
-            <li>Verizon</li>
-          </ul>
-        </td>
-      </tr>
-    </tbody>
-    <caption class="visually-hidden">
-      GTFS Realtime MSAs (click on each MSA for terms and conditions)
-    </caption>
-  </table>
+  <div class="table-responsive my-3">
+    <table class="table_cyan wider mb-1">
+      <thead>
+        <tr>
+          <th scope="col">MSA vendors</th>
+          <th scope="col">MSAs</th>
+          <th scope="col">Pricing structure</th>
+          <th scope="col">Hardware options**</th>
+          <th scope="col">Eligible networks</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Connexionz Ltd</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3"
+              >5-24-70-42-01</a
+            >
+          </td>
+          <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+          <td>Cellular routing kit (with Pepwave MAX BR1 Mini)</td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li class="text-nowrap">T-Mobile</li>
+              <li>Verizon</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>Passio Technologies LLC</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02"
+              >5-24-70-42-02</a
+            >
+          </td>
+          <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+          <td>
+            <ul>
+              <li>Calamp LMU-3641</li>
+              <li>Lilliput RT-V7000 Pro</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li class="text-nowrap">T-Mobile</li>
+              <li>Verizon</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td rowspan="2" style="border-bottom: none">Swiftly Inc</td>
+          <td rowspan="2" style="border-bottom: none">
+            <a
+              href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2"
+              >5-24-70-42-03</a
+            >
+          </td>
+          <td rowspan="2" style="border-bottom: none">Variable fees based on number of vehicles</td>
+          <td>Samsara VG55</td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li>FirstNet</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <ul>
+              <li>Samsung Tab Active 5</li>
+              <li>Cradlepoint R1900</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>WiFi</li>
+              <li>AT&T</li>
+              <li>FirstNet</li>
+              <li>T-Mobile</li>
+              <li>Verizon</li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+      <caption class="visually-hidden">
+        GTFS Realtime MSAs (click on each MSA for terms and conditions)
+      </caption>
+    </table>
+  </div>
   <p class="table-caption">
     **You can always bring your own hardware. These are simply the options you could purchase through each vendor. Purchase
     through a vendor includes a 5-year device warranty.

--- a/src/styles/guide.css
+++ b/src/styles/guide.css
@@ -118,6 +118,20 @@ table {
   border-radius: 4px;
   border-spacing: 0;
 }
+.table-responsive table {
+  border-color: var(--dsdl-gray-40);
+  border-style: solid;
+  /* left border is applied below to cells in first column so it stays in place when scrolling horizontally */
+  border-width: 1px 1px 1px 0;
+  border-radius: 0;
+}
+.table-responsive thead th:first-child,
+.table-responsive tbody th:first-child,
+.table-responsive tbody td:first-child {
+  position: sticky;
+  left: 0;
+  border-left: 1px solid var(--dsdl-gray-40);
+}
 /* Apply a border to the right of all but the last column */
 th:not(:last-child),
 td:not(:last-child) {
@@ -153,14 +167,6 @@ td ol {
 .table-responsive {
   container-name: responsive-table-wrapper;
   container-type: inline-size;
-}
-
-/* Magic numbers decided based on current table content. */
-@container responsive-table-wrapper (max-width: calc(720rem / 16)) {
-  /* Variables can't be used here yet. */
-  .wider {
-    min-width: calc(var(--spacing-base) * 120);
-  }
 }
 
 /* COMPARISON BLOCK */

--- a/src/styles/guide.css
+++ b/src/styles/guide.css
@@ -164,10 +164,6 @@ td ol {
 .table_cyan th {
   background-color: var(--dsdl-cyan-10);
 }
-.table-responsive {
-  container-name: responsive-table-wrapper;
-  container-type: inline-size;
-}
 
 /* COMPARISON BLOCK */
 

--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -133,232 +133,238 @@ with contactless hardware and fare-calculation and payment-processing software.'
     Onboard, on-platform, and mobile fare inspection devices that are equipped to read riders’ contactless bank cards and smart
     devices.
   </p>
-  <table class="table_yellow my-3">
-    <thead>
-      <tr>
-        <th scope="col">Vendors</th>
-        <th scope="col">MSAs</th>
-        <th scope="col">Transit Processor integrations</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>INIT</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
-            >5-21-70-28-01</a
-          >
-        </td>
-        <td>
-          <ul>
-            <li>INIT</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>Kuba</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-02"
-            >5-21-70-28-02</a
-          >
-        </td>
-        <td>
-          <ul>
-            <li>Enghouse</li>
-            <li>Littlepay</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>SC Soft</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-03"
-            >5-21-70-28-03</a
-          >
-        </td>
-        <td>
-          <ul>
-            <li>Enghouse</li>
-            <li>Littlepay</li>
-          </ul>
-        </td>
-      </tr>
-    </tbody>
-    <caption class="visually-hidden">
-      PADs (Payment Acceptance Devices) MSAs (click on each MSA for terms and conditions)
-    </caption>
-  </table>
+  <div class="table-responsive my-3">
+    <table class="table_yellow mb-1">
+      <thead>
+        <tr>
+          <th scope="col">Vendors</th>
+          <th scope="col">MSAs</th>
+          <th scope="col">Transit Processor integrations</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>INIT</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
+              >5-21-70-28-01</a
+            >
+          </td>
+          <td>
+            <ul>
+              <li>INIT</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>Kuba</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-02"
+              >5-21-70-28-02</a
+            >
+          </td>
+          <td>
+            <ul>
+              <li>Enghouse</li>
+              <li>Littlepay</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>SC Soft</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-03"
+              >5-21-70-28-03</a
+            >
+          </td>
+          <td>
+            <ul>
+              <li>Enghouse</li>
+              <li>Littlepay</li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+      <caption class="visually-hidden">
+        PADs (Payment Acceptance Devices) MSAs (click on each MSA for terms and conditions)
+      </caption>
+    </table>
+  </div>
 
   <h4 class="mt-3">Transit Processor MSAs</h4>
   <p>
     Software that instantly determines the correct fare for a trip based on distance, applicable discounts, and frequency of
     travel.
   </p>
-  <table class="table_yellow my-3">
-    <thead>
-      <tr>
-        <th scope="col">Vendors</th>
-        <th scope="col">MSAs</th>
-        <th scope="col">Rider benefits & discounts</th>
-        <th scope="col">Fare calculation</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Bytemark</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-04"
-            >5-21-70-28-04</a
-          >
-        </td>
-        <td>Not integrated with Cal-ITP rider benefits</td>
-        <td>
-          <ul>
-            <li>Basic transfers</li>
-            <li>Fare capping</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>Enghouse</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-05"
-            >5-21-70-28-05</a
-          >
-        </td>
-        <td>
-          <ul>
-            <li>Older adults</li>
-            <li>Veterans</li>
-            <li>Medicare recipients</li>
-            <li>CalFresh recipients</li>
-          </ul>
-        </td>
-        <td>
-          <ul>
-            <li>Basic transfers</li>
-            <li>Fare capping</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>INIT</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
-            >5-21-70-28-01</a
-          >
-        </td>
-        <td>Not integrated with Cal-ITP rider benefits</td>
-        <td>
-          <ul>
-            <li>Basic transfers</li>
-            <li>Fare capping</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>Littlepay</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-06"
-            >5-21-70-28-06</a
-          >
-        </td>
-        <td>
-          <ul>
-            <li>Older adults</li>
-            <li>Veterans</li>
-            <li>Medicare recipients</li>
-            <li>CalFresh recipients</li>
-          </ul>
-        </td>
-        <td>
-          <ul>
-            <li>Basic transfers</li>
-            <li>Fare capping</li>
-          </ul>
-        </td>
-      </tr>
-    </tbody>
-    <caption class="visually-hidden">
-      Transit Processor MSAs (click on each MSA for terms and conditions)
-    </caption>
-  </table>
+  <div class="table-responsive my-3">
+    <table class="table_yellow mb-1">
+      <thead>
+        <tr>
+          <th scope="col">Vendors</th>
+          <th scope="col">MSAs</th>
+          <th scope="col">Rider benefits & discounts</th>
+          <th scope="col">Fare calculation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Bytemark</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-04"
+              >5-21-70-28-04</a
+            >
+          </td>
+          <td>Not integrated with Cal-ITP rider benefits</td>
+          <td>
+            <ul>
+              <li>Basic transfers</li>
+              <li>Fare capping</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>Enghouse</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-05"
+              >5-21-70-28-05</a
+            >
+          </td>
+          <td>
+            <ul>
+              <li>Older adults</li>
+              <li>Veterans</li>
+              <li>Medicare recipients</li>
+              <li>CalFresh recipients</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Basic transfers</li>
+              <li>Fare capping</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>INIT</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
+              >5-21-70-28-01</a
+            >
+          </td>
+          <td>Not integrated with Cal-ITP rider benefits</td>
+          <td>
+            <ul>
+              <li>Basic transfers</li>
+              <li>Fare capping</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>Littlepay</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-06"
+              >5-21-70-28-06</a
+            >
+          </td>
+          <td>
+            <ul>
+              <li>Older adults</li>
+              <li>Veterans</li>
+              <li>Medicare recipients</li>
+              <li>CalFresh recipients</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Basic transfers</li>
+              <li>Fare capping</li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+      <caption class="visually-hidden">
+        Transit Processor MSAs (click on each MSA for terms and conditions)
+      </caption>
+    </table>
+  </div>
 
   <h5 class="mt-3 h4">Payment Processor MSAs</h5>
   <p>
     Software embedded in fare validators that transmits money from a rider’s bank card to the Transit Provider’s bank account.
   </p>
-  <table class="table_yellow my-3">
-    <thead>
-      <tr>
-        <th scope="col">Vendors</th>
-        <th scope="col">MSAs</th>
-        <th scope="col">Types of transactions</th>
-        <th scope="col">Payment networks</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Fiserv*</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-02"
-            >5-22-70-22-02</a
-          >
-        </td>
-        <td>
-          <ul>
-            <li>Credit</li>
-            <li>Debit</li>
-            <li>Mobile wallet</li>
-          </ul>
-        </td>
-        <td>
-          <ul>
-            <li>American Express</li>
-            <li>Discover</li>
-            <li>Mastercard</li>
-            <li>Visa</li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td>Elavon*</td>
-        <td>
-          <a
-            href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-01"
-            >5-22-70-22-01</a
-          >
-        </td>
-        <td>
-          <ul>
-            <li>Credit</li>
-            <li>Debit</li>
-            <li>Mobile wallet</li>
-          </ul>
-        </td>
-        <td>
-          <ul>
-            <li>American Express</li>
-            <li>Discover</li>
-            <li>Mastercard</li>
-            <li>Visa</li>
-          </ul>
-        </td>
-      </tr>
-    </tbody>
-    <!-- are these captions redundant? -->
-    <caption class="visually-hidden">
-      Payment Processor MSAs (click on each MSA for terms and conditions)
-    </caption>
-  </table>
+  <div class="table-responsive my-3">
+    <table class="table_yellow mb-1">
+      <thead>
+        <tr>
+          <th scope="col">Vendors</th>
+          <th scope="col">MSAs</th>
+          <th scope="col">Types of transactions</th>
+          <th scope="col">Payment networks</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Fiserv*</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-02"
+              >5-22-70-22-02</a
+            >
+          </td>
+          <td>
+            <ul>
+              <li>Credit</li>
+              <li>Debit</li>
+              <li>Mobile wallet</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>American Express</li>
+              <li>Discover</li>
+              <li>Mastercard</li>
+              <li>Visa</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>Elavon*</td>
+          <td>
+            <a
+              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-01"
+              >5-22-70-22-01</a
+            >
+          </td>
+          <td>
+            <ul>
+              <li>Credit</li>
+              <li>Debit</li>
+              <li>Mobile wallet</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>American Express</li>
+              <li>Discover</li>
+              <li>Mastercard</li>
+              <li>Visa</li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+      <!-- are these captions redundant? -->
+      <caption class="visually-hidden">
+        Payment Processor MSAs (click on each MSA for terms and conditions)
+      </caption>
+    </table>
+  </div>
   <p class="table-caption">*Available to California agencies only.</p>
 
   <h4 class="mt-3">Draft a Scope of Work (SOW)</h4>

--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -188,9 +188,6 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
       </tbody>
-      <caption class="visually-hidden">
-        PADs (Payment Acceptance Devices) MSAs (click on each MSA for terms and conditions)
-      </caption>
     </table>
   </div>
 
@@ -289,9 +286,6 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
       </tbody>
-      <caption class="visually-hidden">
-        Transit Processor MSAs (click on each MSA for terms and conditions)
-      </caption>
     </table>
   </div>
 
@@ -359,10 +353,6 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
       </tbody>
-      <!-- are these captions redundant? -->
-      <caption class="visually-hidden">
-        Payment Processor MSAs (click on each MSA for terms and conditions)
-      </caption>
     </table>
   </div>
   <p class="table-caption">*Available to California agencies only.</p>

--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -134,7 +134,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
     devices.
   </p>
   <div class="table-responsive my-3">
-    <table class="table_yellow mb-1">
+    <table class="table_yellow mb-2">
       <thead>
         <tr>
           <th scope="col">Vendors</th>
@@ -144,7 +144,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
       </thead>
       <tbody>
         <tr>
-          <td>INIT</td>
+          <th>INIT</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
@@ -158,7 +158,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
         <tr>
-          <td>Kuba</td>
+          <th>Kuba</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-02"
@@ -173,7 +173,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
         <tr>
-          <td>SC Soft</td>
+          <th>SC Soft</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-03"
@@ -200,7 +200,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
     travel.
   </p>
   <div class="table-responsive my-3">
-    <table class="table_yellow mb-1">
+    <table class="table_yellow mb-2">
       <thead>
         <tr>
           <th scope="col">Vendors</th>
@@ -211,7 +211,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
       </thead>
       <tbody>
         <tr>
-          <td>Bytemark</td>
+          <th>Bytemark</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-04"
@@ -227,7 +227,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
         <tr>
-          <td>Enghouse</td>
+          <th>Enghouse</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-05"
@@ -250,7 +250,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
         <tr>
-          <td>INIT</td>
+          <th>INIT</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
@@ -266,7 +266,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
         <tr>
-          <td>Littlepay</td>
+          <th>Littlepay</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-06"
@@ -300,7 +300,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
     Software embedded in fare validators that transmits money from a rider’s bank card to the Transit Provider’s bank account.
   </p>
   <div class="table-responsive my-3">
-    <table class="table_yellow mb-1">
+    <table class="table_yellow mb-2">
       <thead>
         <tr>
           <th scope="col">Vendors</th>
@@ -311,7 +311,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
       </thead>
       <tbody>
         <tr>
-          <td>Fiserv*</td>
+          <th>Fiserv*</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-02"
@@ -335,7 +335,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
           </td>
         </tr>
         <tr>
-          <td>Elavon*</td>
+          <th>Elavon*</th>
           <td>
             <a
               href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-01"


### PR DESCRIPTION
Closes #845 

---

- Adds `.table-responsive` wrapper to tables in guide so that only they scroll horizontally, not the whole page
- Makes the left columns of responsive tables sticky when scrolling them horizontally

Side effects:
- Converted the first cell of body rows to a `<th>`, which seems semantically correct but changes the original design – they now have the same background color and bolding as column header cells.
- Removes the "wider" class, which was used on only one table (on the GTFS-RT page), because it made the untstuck columns too wide to fit between stuck column and edge of the scrolling container.
- Responsive tables no longer have rounded corners, because it resulted in odd visual artifacts when combined with the sticky column behavior.

![Demo of table scrolling on a phone-size screen](https://github.com/user-attachments/assets/387e57c1-3e59-40c5-a892-027dcfda1492)
