### PR TITLE
feat: add support for resources with multiple tags

### DIFF
--- a/src/_data/resources.json
+++ b/src/_data/resources.json
@@ -2,7 +2,7 @@
   {
     "title": "Sample User Agreement",
     "slug": "user-agreement-gtfs",
-    "tag": "GTFS-RT",
+    "tags": ["GTFS-RT"],
     "thumbnail": "/uploads/resources/thumbnails/sample-user-agreement.png",
     "description": "To enter into contract with your selected vendor",
     "filename": "/uploads/resources/Cal.ITP.User-Agreement-Contract-Form-MSA-5-21-70-28.docx",
@@ -12,7 +12,7 @@
   {
     "title": "Scope of work template",
     "slug": "sow-gtfs",
-    "tag": "GTFS-RT",
+    "tags": ["GTFS-RT"],
     "thumbnail": "/uploads/resources/thumbnails/scope-of-work.png",
     "description": "Document your project needs and goals to send to vendors",
     "filename": "/uploads/resources/Cal-ITP.GTFS.RT.MSA.SOW.Template.and.Guidance.docx",
@@ -22,7 +22,7 @@
   {
     "title": "Email template",
     "slug": "email-template-gtfs",
-    "tag": "GTFS-RT",
+    "tags": ["GTFS-RT"],
     "thumbnail": "/uploads/resources/thumbnails/email-template.png",
     "description": "To facilitate vendor outreach",
     "filename": "/uploads/resources/Cal.ITP.GTFS.RT.MSA.Vendor.Contact.Email.Template.docx",
@@ -32,7 +32,7 @@
   {
     "title": "Sample User Agreements",
     "slug": "user-agreement-tap-to-pay",
-    "tag": "Tap2Pay",
+    "tags": ["Tap2Pay"],
     "thumbnail": "/uploads/resources/thumbnails/sample-user-agreement.png",
     "description": "To enter into contract with your selected vendor",
     "filename": "/uploads/resources/Cal.ITP.Contactless.User-Agreements.zip",
@@ -42,7 +42,7 @@
   {
     "title": "Scope of work template",
     "slug": "sow-tap-to-pay",
-    "tag": "Tap2Pay",
+    "tags": ["Tap2Pay"],
     "thumbnail": "/uploads/resources/thumbnails/scope-of-work.png",
     "description": "Document your project needs and goals to send to vendors",
     "filename": "/uploads/resources/Cal-ITP.Contactless.MSA.SOW.Template.and.Guidance.docx",
@@ -51,7 +51,7 @@
   {
     "title": "Email templates",
     "slug": "email-template-tap-to-pay",
-    "tag": "Tap2Pay",
+    "tags": ["Tap2Pay"],
     "thumbnail": "/uploads/resources/thumbnails/email-template.png",
     "description": "To facilitate vendor outreach",
     "filename": "/uploads/resources/Cal.ITP.Contactless.MSA.Vendor.Contact.Email.Template.docx",
@@ -61,7 +61,7 @@
   {
     "title": "Statewide Fare Guidelines Toolkit",
     "slug": "statewide-fare-guidelines-toolkit",
-    "tag": "Tap2Pay",
+    "tags": ["Tap2Pay"],
     "thumbnail": "/uploads/resources/thumbnails/statewide-fare-guidelines-toolkit.png",
     "description": "",
     "filename": "/uploads/resources/Cal-ITP.Statewide.Fare.Guidelines.Toolkit.pdf",
@@ -71,7 +71,7 @@
   {
     "title": "Contactless Payments Introduction",
     "slug": "contactless-payments-introduction",
-    "tag": "Tap2Pay",
+    "tags": ["Tap2Pay"],
     "thumbnail": "/uploads/resources/thumbnails/contactless-payments-introduction.png",
     "description": "To enter into contract with your selected vendor",
     "filename": "/uploads/resources/Cal-ITP.Contactless.Payments.Introduction.pdf",
@@ -81,7 +81,7 @@
   {
     "title": "MSA Cost Estimation Tool",
     "slug": "msa-cost-estimation-tool",
-    "tag": "Tap2Pay",
+    "tags": ["Tap2Pay"],
     "thumbnail": "/uploads/resources/thumbnails/msa-cost-estimation-tool.png",
     "description": "To enter into contract with your selected vendor",
     "filename": "/uploads/resources/Cal-ITP.MSA-Cost-Estimation-Tool.xlsx",
@@ -91,7 +91,7 @@
   {
     "title": "Marketing materials",
     "slug": "marketing-materials",
-    "tag": "Tap2Pay",
+    "tags": ["Rider benefits", "Tap2Pay"],
     "thumbnail": "/uploads/resources/thumbnails/marketing-materials.png",
     "description": "To facilitate customer communications and marketing",
     "filename": "/uploads/resources/Cal-ITP.Marketing.Materials.zip",

--- a/src/_includes/dl-card.html
+++ b/src/_includes/dl-card.html
@@ -1,16 +1,16 @@
 {% comment %}
   Usage:
       {% assign dl_img = "https://placehold.co/272x352/white/black?text=8.5×11" %}
-      {% assign dl_tag = "GTFS-RT" %}
+      {% assign dl_tags = ["GTFS-RT"] %}
       {% assign dl_title = "Scope of Work template" %}
       {% assign dl_description = "to document your project needs and goals to send to vendors" %}
       {% assign dl_view_url = "/resources/assets/gtfs-rt_scope-of-work-template.docx" %}
       {% assign dl_download_url = "/resources/gtfs-rt_scope-of-work-template" %}
-      {% include 'dl-card.html' img:dl_img tag:dl_tag title:dl_title description:dl_description view_url:dl_view_url download_url:dl_download_url %}
+      {% include 'dl-card.html' img:dl_img tags:dl_tags title:dl_title description:dl_description view_url:dl_view_url download_url:dl_download_url %}
 
   Parameters:
       * img (string)          - URL or path to image to be used for the thumbnail
-      * tag (string)          - text for the tag indicating the download category
+      * tags (Array of strings) - text for the tags indicating the download categories
       * title (string)        - the download's title
       * view_url (string)     - URL to the download's detail page
       * download_url (string) - URL to the download itself
@@ -25,7 +25,11 @@
 <div class="dl-card">
   <img class="dl-card-thumbnail" src="{{ img }}" alt="">
   <div class="dl-card-text">
-    <div class="dl-tag">{{ tag }}</div>
+    <div class="d-flex flex-row gap-2">
+      {% for tag in tags %}
+        <div class="dl-tag">{{ tag }}</div>
+      {% endfor %}
+    </div>
     <h3 class="h5 mt-3 mb-1">{{ title }}</h3>
     <p class="mb-3">{{ description | default: '' }}</p>
     <div class="dl-card-buttons">

--- a/src/_includes/downloadable-resources.html
+++ b/src/_includes/downloadable-resources.html
@@ -2,7 +2,7 @@
   Usage:
     {% include 'related-documents.html' resource_tag:'Tap2Pay' %}
   Parameters:
-    * resource_tag (string) - the name of a tag to filter on
+    * resource_tags (Array of strings) - the names of a tags to filter on
   Optional Parameters:
     * heading (string) : 'Downloadable resources' - the heading to display above the cards
     * current_slug (string) : to avoid displaying a card for the resource currently being previewed
@@ -14,22 +14,24 @@
   <h2 class="h3 text-center pt-4 m-4 pb-2">{{ heading | default: 'Downloadable resources' }}</h2>
   <div class="d-flex flex-md-row flex-column flex-wrap justify-content-center align-content-center gap-4">
     {% for resource in resources %}
-      {% if resource.tag == resource_tag and resource.slug != current_slug %}
-        {% assign dl_img = resource.thumbnail %}
-        {% assign dl_tag = resource_tag %}
-        {% assign dl_title = resource.title %}
-        {% assign dl_description = resource.description %}
-        {% assign dl_view_url = '/resources/' | append: resource.slug %}
-        {% assign dl_download_url = resource.filename %}
-        {% include 'dl-card.html',
-          img: dl_img,
-          tag: dl_tag,
-          title: dl_title,
-          description: dl_description,
-          view_url: dl_view_url,
-          download_url: dl_download_url
-        %}
-      {% endif %}
+      {% for tag in resource_tags %}
+        {% if resource.tags contains tag and resource.slug != current_slug %}
+          {% assign dl_img = resource.thumbnail %}
+          {% assign dl_tags = resource.tags %}
+          {% assign dl_title = resource.title %}
+          {% assign dl_description = resource.description %}
+          {% assign dl_view_url = '/resources/' | append: resource.slug %}
+          {% assign dl_download_url = resource.filename %}
+          {% include 'dl-card.html',
+            img: dl_img,
+            tags: dl_tags,
+            title: dl_title,
+            description: dl_description,
+            view_url: dl_view_url,
+            download_url: dl_download_url
+          %}
+        {% endif %}
+      {% endfor %}
     {% endfor %}
   </div>
 </div>

--- a/src/_layouts/doc-preview.html
+++ b/src/_layouts/doc-preview.html
@@ -8,14 +8,16 @@ stylesheet: doc-preview.css
 
 {% assign url = page.url %}
 {% assign resource = resources | where: 'slug', page.fileSlug | first %}
-{% assign resourceTag = resource.tag %}
+{% assign resourceTags = resource.tags %}
 
 <section class="dl-hero my-4">
   <div class="container">
     <div class="row">
       <div class="dl-hero-text col-12 col-lg-4 offset-lg-1">
         <div>
-          <div class="dl-tag">{{ resource.tag }}</div>
+          {% for tag in resourceTags %}
+            <div class="dl-tag">{{ tag }}</div>
+          {% endfor %}
         </div>
         <h1 class="mt-2 mb-lg-3 text-start">{{ resource.title }}</h1>
         <a class="dl-button my-3 my-lg-4" href="{{resource.filename}}" download>Download</a>
@@ -28,5 +30,9 @@ stylesheet: doc-preview.css
     </div>
   </div>
 </section>
-{% include 'downloadable-resources.html', resource_tag: resourceTag, heading: 'Related documents', current_slug: resource.slug %}
+{% include 'downloadable-resources.html',
+  resource_tags: resourceTags,
+  heading: 'Related documents',
+  current_slug: resource.slug
+%}
 <div class="spacer-10"></div>

--- a/src/demo.html
+++ b/src/demo.html
@@ -5,6 +5,7 @@ stylesheet: guide.css
 title: Component demo
 description: >
   A page to view individual layout components as they are completed
+dummyTags: ["GTFS-RT"]
 noindex: true
 show_call_to_action: true
 ---
@@ -347,7 +348,7 @@ show_call_to_action: true
     </table>
   </div>
 </div>
-{% include 'downloadable-resources.html' resource_tag='GTFS-RT' %}
+{% include 'downloadable-resources.html' resource_tags=dummyTags %}
 <h2 class="my-5">Download hero</h2>
 <section class="dl-hero my-4">
   <div class="container">

--- a/src/demo.html
+++ b/src/demo.html
@@ -348,7 +348,7 @@ show_call_to_action: true
     </table>
   </div>
 </div>
-{% include 'downloadable-resources.html' resource_tags=dummyTags %}
+{% include 'downloadable-resources.html', resource_tags: dummyTags %}
 <h2 class="my-5">Download hero</h2>
 <section class="dl-hero my-4">
   <div class="container">

--- a/src/gtfs-realtime.html
+++ b/src/gtfs-realtime.html
@@ -2,7 +2,7 @@
 layout: main
 title: GTFS Realtime
 stylesheet: guide.css
-resourceTag: GTFS-RT
+resourceTags: ["GTFS-RT"]
 description: Follow this step-by-step guide to launch a GTFS Realtime program and share live transit data with your riders.
 ---
 <div class="container">
@@ -306,7 +306,7 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
     settings that not all GTFS Realtime consuming applications may be able to support.
   </p>
 </div>
-{% include 'downloadable-resources.html', resource_tag: resourceTag %}
+{% include 'downloadable-resources.html', resource_tags: resourceTags %}
 <div class="spacer-10"></div>
 <div class="container">
   <h2 class="mt-0 mb-3 pb-3">Related</h2>

--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -2,7 +2,7 @@
 layout: main
 title: Tap to pay
 stylesheet: guide.css
-resourceTag: Tap2Pay
+resourceTags: ["Tap2Pay"]
 description: Learn how to roll out a tap to pay program at your transit agency to accept contactless credit and debit cards, prepaid cards, and mobile wallets.
 ---
 <div class="container">
@@ -507,7 +507,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
     <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">hello@calitp.org</a>.
   </h4>
 </div>
-{% include 'downloadable-resources.html', resource_tag: resourceTag %}
+{% include 'downloadable-resources.html', resource_tags: resourceTags %}
 <div class="spacer-10"></div>
 <div class="container">
   <h2 class="mt-0 mb-3 pb-3">Related</h2>


### PR DESCRIPTION
resolves #877

## how to test

1. [/tap-to-pay](https://deploy-preview-888--cal-itp-mobility-marketplace.netlify.app/tap-to-pay) and [/gtfs-realtime](https://deploy-preview-888--cal-itp-mobility-marketplace.netlify.app/gtfs-realtime) display the same downloadable resources as before
1. individual doc preview pages show the same related resources as before
1. [/resources/marketing-materials](https://deploy-preview-888--cal-itp-mobility-marketplace.netlify.app/resources/marketing-materials/) displays an additional `Rider benefits` tag
1. [/demo](https://deploy-preview-888--cal-itp-mobility-marketplace.netlify.app/demo/) displays `GTFS-RT` resources (fixes a bug i found along the way)
