### PR TITLE
feat: add Benefits gallery card to homepage

### DIFF
--- a/src/_data/galleryCards.json
+++ b/src/_data/galleryCards.json
@@ -30,5 +30,13 @@
     "name": "GTFS Realtime",
     "img": "showcase_gtfs-rt.jpg",
     "imgAlt": "A collage showing a GTFS code snippet alongside a phone screen that shows a bus approaching in real time."
+  },
+  {
+    "title": "Tap for rider benefits",
+    "description": "Offer tap to pay reduced fares for older adults, veterans, CalFresh recipients, and more",
+    "href": "/rider-benefits/",
+    "name": "rider benefits",
+    "img": "showcase_rider-benefits.jpg",
+    "imgAlt": "A collage of a web page enrolling a rider in a reduced fare, and an older man with a walker using contactless payments to board a bus and get a reduced fare."
   }
 ]


### PR DESCRIPTION
resolves #874

[Figma](https://www.figma.com/design/TfWk1iDHdlt7bSA3DjQuQv/Mobility-Marketplace?node-id=12332-22189&m=dev)
<img width="540" height="767" alt="Screenshot 2026-04-21 at 10 59 03 AM" src="https://github.com/user-attachments/assets/3115a94c-a13c-485d-972f-f36c18449239" />