### PR TITLE
Feat: Benefits downloadable resource and "Related" section

### DIFF
--- a/src/data-plans.html
+++ b/src/data-plans.html
@@ -316,9 +316,9 @@ connectivity to modernize and improve the rider experience.' %}
   <h2 class="mt-0 mb-3 pb-3">Related</h2>
   <nav class="related-nav row mb-4 pb-3 pb-0" aria-label="Related">
     <div class="col-md">
-      <a class="related-nav-link" href="/tap-to-pay">
+      <a class="related-nav-link" href="/rider-benefits">
         <span class="arrow" aria-label="(previous page)">←</span>
-        <span class="text">Learn more about tap to pay rider benefits</span>
+        <span class="text">Make your tap to pay program more robust with <b>rider benefits</b> & discounts</span>
       </a>
     </div>
     <div class="col-md">

--- a/src/gtfs-realtime.html
+++ b/src/gtfs-realtime.html
@@ -319,7 +319,7 @@ description: Follow this step-by-step guide to launch a GTFS Realtime program an
     </div>
     <div class="col-md">
       <a class="related-nav-link related-nav-link_next" href="/tap-to-pay">
-        <span class="text">Explore tap to pay to bring contactless payments to your fleet</span>
+        <span class="text">Explore <b>tap to pay</b> to bring contactless payments to your fleet</span>
         <span class="arrow" aria-label="(next page)">→</span>
       </a>
     </div>

--- a/src/rider-benefits.html
+++ b/src/rider-benefits.html
@@ -2,6 +2,7 @@
 layout: main
 title: Rider benefits
 stylesheet: guide.css
+resourceTags: ["Rider benefits"]
 description: Learn how to set up Cal-ITP Benefits at your transit agency and extend contactless payments to riders who receive reduced fares.
 ---
 <div class="container">
@@ -193,3 +194,4 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
 
   <h4 class="mt-0">Have questions? Email us at <a href="mailto:hello@calitp.org">hello@calitp.org</a>.</h4>
 </div>
+{% include 'downloadable-resources.html', resource_tags: resourceTags %}

--- a/src/rider-benefits.html
+++ b/src/rider-benefits.html
@@ -195,3 +195,21 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
   <h4 class="mt-0">Have questions? Email us at <a href="mailto:hello@calitp.org">hello@calitp.org</a>.</h4>
 </div>
 {% include 'downloadable-resources.html', resource_tags: resourceTags %}
+<div class="spacer-10"></div>
+<div class="container">
+  <h2 class="mt-0 mb-3 pb-3">Related</h2>
+  <nav class="related-nav row mb-4 pb-3 pb-0" aria-label="Related">
+    <div class="col-md">
+      <a class="related-nav-link" href="/gtfs-realtime">
+        <span class="arrow" aria-label="(previous page)">←</span>
+        <span class="text">Build on Schedule data with <b>GTFS Realtime</b>. Explore the guide</span>
+      </a>
+    </div>
+    <div class="col-md">
+      <a class="related-nav-link related-nav-link_next" href="/tap-to-pay">
+        <span class="text">Explore <b>tap to pay</b> to bring contactless payments to your fleet</span>
+        <span class="arrow" aria-label="(next page)">→</span>
+      </a>
+    </div>
+  </nav>
+</div>

--- a/src/rider-benefits.html
+++ b/src/rider-benefits.html
@@ -200,14 +200,14 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
   <h2 class="mt-0 mb-3 pb-3">Related</h2>
   <nav class="related-nav row mb-4 pb-3 pb-0" aria-label="Related">
     <div class="col-md">
-      <a class="related-nav-link" href="/gtfs-realtime">
+      <a class="related-nav-link" href="/tap-to-pay">
         <span class="arrow" aria-label="(previous page)">←</span>
-        <span class="text">Build on Schedule data with <b>GTFS Realtime</b>. Explore the guide</span>
+        <span class="text">Explore <b>tap to pay</b> to bring contactless payments to your fleet</span>
       </a>
     </div>
     <div class="col-md">
-      <a class="related-nav-link related-nav-link_next" href="/tap-to-pay">
-        <span class="text">Explore <b>tap to pay</b> to bring contactless payments to your fleet</span>
+      <a class="related-nav-link related-nav-link_next" href="/data-plans">
+        <span class="text">Explore how to increase data or save on your <b>data plans</span>
         <span class="arrow" aria-label="(next page)">→</span>
       </a>
     </div>

--- a/src/route-scheduling.html
+++ b/src/route-scheduling.html
@@ -198,7 +198,7 @@ description: Learn how transit providers can get service planning and scheduling
     <div class="col-md">
       <a class="related-nav-link" href="/data-plans">
         <span class="arrow" aria-label="(previous page)">←</span>
-        <span class="text">Explore how to increase data or save on your data plans</span>
+        <span class="text">Explore how to increase data or save on your <b>data plans</b></span>
       </a>
     </div>
     <div class="col-md">

--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -520,7 +520,7 @@ with contactless hardware and fare-calculation and payment-processing software.'
     </div>
     <div class="col-md">
       <a class="related-nav-link related-nav-link_next" href="/rider-benefits">
-        <span class="text">Make your tap to pay program more robust with rider benefits & discounts</span>
+        <span class="text">Make your tap to pay program more robust with <b>rider benefits</b> & discounts</span>
         <span class="arrow" aria-label="(next page)">→</span>
       </a>
     </div>

--- a/src/tap-to-pay.html
+++ b/src/tap-to-pay.html
@@ -519,8 +519,8 @@ with contactless hardware and fare-calculation and payment-processing software.'
       </a>
     </div>
     <div class="col-md">
-      <a class="related-nav-link related-nav-link_next" href="/data-plans">
-        <span class="text">Explore how to increase data or save on your data plans</span>
+      <a class="related-nav-link related-nav-link_next" href="/rider-benefits">
+        <span class="text">Make your tap to pay program more robust with rider benefits & discounts</span>
         <span class="arrow" aria-label="(next page)">→</span>
       </a>
     </div>


### PR DESCRIPTION
Closes #890 

**Downloadable resources**
- Adds `resourceTags: ["Rider benefits"]` to `rider-benefits` frontmatter and adds usage of `downloadable-resources` include template to `rider-benefits`

**"Related" section**
- Adds the "Related" section to `rider-benefits`, and updates the next link on `tap-to-pay` to go to `/rider-benefits`
  - `rider-benefits`'s "previous" link goes to `/gtfs-realtime` and "next" link goes to `/tap-to-pay`
  - **Open question**: this implementation matches what Figma shows, but I'm wondering if the design intention was for these "previous" and "next" links to follow the ordering of the nav links, in which case `rider-benefits`'s "previous" link should be to `/tap-to-pay` and "next" link should be to `/data-plans`. `data-plans`'s "previous" link would be for `/rider-benefits`. 
  - **Open question**: is the styling on the "next" link something that we're introducing as a part of this Benefits page effort? Or was that a style in Figma that was never implemented, in which case I guess the options are to ignore it/remove it from Figma, just implement it, or leave it as something that we want to implement but not right now?

| Figma | Currently live MobiMart |
| --- | --- |
| <img width="1680" height="1005" alt="image" src="https://github.com/user-attachments/assets/6fbb8687-fddc-4a8e-98ef-e72563d55375" /> | <img width="1680" height="1005" alt="image" src="https://github.com/user-attachments/assets/f28e3859-2000-4812-b548-add839901d1b" /> |
 
