### PR TITLE
Style: related-nav-link hover and focus states

### DIFF
--- a/src/styles/related-nav.css
+++ b/src/styles/related-nav.css
@@ -15,20 +15,22 @@
   color: var(--button-text-color);
   text-decoration: none;
 }
-.related-nav-link:focus {
-  background-color: var(--dsdl-cyan-60);
-  outline: var(--button-focus-outline);
-  outline-offset: var(--button-focus-outline-offset);
-  color: white;
+.related-nav-link:active,
+.related-nav-link:focus,
+.related-nav-link:hover {
+  color: var(--button-active-text-color);
 }
+.related-nav-link:focus,
 .related-nav-link:hover {
   background-color: var(--dsdl-cyan-60);
-  color: white;
+}
+.related-nav-link:focus {
+  outline: var(--button-focus-outline);
+  outline-offset: var(--button-focus-outline-offset);
 }
 .related-nav-link:active {
   border-color: var(--button-active-border-color);
   background-color: var(--button-active-bg-color);
-  color: var(--button-active-text-color);
 }
 .related-nav-link > .text {
   flex-grow: 1;

--- a/src/styles/related-nav.css
+++ b/src/styles/related-nav.css
@@ -16,8 +16,10 @@
   text-decoration: none;
 }
 .related-nav-link:focus {
+  background-color: var(--dsdl-cyan-60);
   outline: var(--button-focus-outline);
   outline-offset: var(--button-focus-outline-offset);
+  color: white;
 }
 .related-nav-link:hover {
   background-color: var(--dsdl-cyan-60);

--- a/src/styles/related-nav.css
+++ b/src/styles/related-nav.css
@@ -20,8 +20,8 @@
   outline-offset: var(--button-focus-outline-offset);
 }
 .related-nav-link:hover {
-  border-color: var(--button-hover-border-color);
-  background-color: var(--button-hover-bg-color);
+  background-color: var(--dsdl-cyan-60);
+  color: white;
 }
 .related-nav-link:active {
   border-color: var(--button-active-border-color);


### PR DESCRIPTION
Closes #892 
(more details in the ticket)

In this branch:
**Hover**
<img width="872" height="293" alt="Screenshot from 2026-04-22 14-49-44" src="https://github.com/user-attachments/assets/04a59972-d4bb-4d67-8925-05b78b7b0b07" />


**Focus**

<img width="872" height="293" alt="image" src="https://github.com/user-attachments/assets/91315f90-1938-4e35-8d17-a86e18db63c2" />
