### PR TITLE
Fix: mark external links on Benefits page

### DIFF
--- a/src/rider-benefits.html
+++ b/src/rider-benefits.html
@@ -16,7 +16,7 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
   <p>
     Created by the California Integrated Travel Project, Cal-ITP Benefits is a first-of-its-kind, open-source web app. Using the
     <a href="https://digitalidstrategy.cdt.ca.gov/">California Identity Gateway<span aria-label="(external link)">↗</span></a> and existing data sources like
-    <a href="https://login.gov">Login.gov</a>, riders can securely verify their identity and eligibility for reduced fares.
+    <a href="https://login.gov">Login.gov<span aria-label="(external link)">↗</span></a>, riders can securely verify their identity and eligibility for reduced fares.
   </p>
   <p>
     Transit providers who choose Cal-ITP Benefits get a reimagined approach to discount programs that integrates with open-loop
@@ -58,7 +58,7 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
   <h3 class="numbered numbered_green" data-number="1">Fill out the onboarding form</h3>
   <ul>
     <li>
-      The <a href="https://share.hsforms.com/1LsDFiHI-TJieFrBEgZyD4g3aanu">Cal-ITP onboarding form</a>, which will take about 10
+      The <a href="https://share.hsforms.com/1LsDFiHI-TJieFrBEgZyD4g3aanu">Cal-ITP onboarding form<span aria-label="(external link)">↗</span></a>, which will take about 10
        minutes to fill out, will make onboarding faster for your organization as we process details, including which discount
        groups are applicable and how to represent your service on Cal-ITP Benefits. 
     </li>
@@ -76,11 +76,11 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
     <li><b>Older adults:</b> Riders 65 and older
     <li><b>Veterans:</b> Riders who served in the military, naval, or air service
     <li><b>Medicare cardholders:</b> Riders of any age who have Medicare coverage
-    <li><b>Individuals with low income:</b> Riders who receive <a href="https://www.getcalfresh.org/en/">CalFresh</a> benefits
+    <li><b>Individuals with low income:</b> Riders who receive <a href="https://www.getcalfresh.org/en/">CalFresh<span aria-label="(external link)">↗</span></a> benefits
   </ul>
   <p>
     Want to learn more about supported enrollment pathways? Check out the <a href="https://docs.calitp.org/benefits/#supported-enrollment-pathways">Cal-ITP Benefits
-    documentation site</a>.
+    documentation site<span aria-label="(external link)">↗</span></a>.
   </p>
 
   <h3 class="numbered numbered_green" data-number="3">Test the system</h3>
@@ -114,7 +114,7 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
 
   <h4 class="mt-3 h5">Make it simpler for all riders to adopt these new behaviors</h4>
   <ul>
-    <li>Refer unbanked/underbanked transit riders to <a href="https://joinbankon.org/">safe, inclusive banking accounts</a>.</li>
+    <li>Refer unbanked/underbanked transit riders to <a href="https://joinbankon.org/">safe, inclusive banking accounts<span aria-label="(external link)">↗</span></a>.</li>
     <li>Offer digital or prepaid card options, which are often cheaper per ride compared to cash payments.</li>
     <li>Cal-ITP Benefits will work with any of the four major credit or debit card schemes that an agency accepts (Visa, Mastercard, Discover, AMEX).
         All cards must be contactless-enabled, and, at this time, only physical cards—not smart devices—will enable transit discounts.</li>
@@ -168,7 +168,7 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
   <h4 class="mt-0">How does Cal-ITP Benefits work?</h4>
   <p>
     When eligible riders enroll in Cal-ITP Benefits, the Cal-ITP Benefits app interfaces with the California Department of Technology
-    <a href="https://digitalidstrategy.cdt.ca.gov/">Identity Gateway</a> to verify benefit eligibility.
+    <a href="https://digitalidstrategy.cdt.ca.gov/">Identity Gateway<span aria-label="(external link)">↗</span></a> to verify benefit eligibility.
   </p>
   <p>
     Then, the app directs the eligible rider to register the credit or debit card they will use to pay for transit through vendors like Littlepay or Switchio so
@@ -179,7 +179,7 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
   </p>
 
   <h4 class="mt-0">Where can I find technical documentation about Cal-ITP Benefits?</h4>
-  <p>Visit our <a href="https://docs.calitp.org/benefits/">documentation site</a> for more information.</p>
+  <p>Visit our <a href="https://docs.calitp.org/benefits/">documentation site<span aria-label="(external link)">↗</span></a> for more information.</p>
 
   <h4 class="mt-0">Does Cal-ITP Benefits charge the rider’s card?</h4>
   <p>


### PR DESCRIPTION
Closes #901 

I counted 8 external links noted in Figma with ↗️

1 was already done for https://github.com/cal-itp/mobility-marketplace/pull/903#discussion_r3148991131, and the remaining 7 were done here.