### PR TITLE
Style: allow more room for pull-quote attribution

### DIFF
--- a/src/_includes/pull-quote.html
+++ b/src/_includes/pull-quote.html
@@ -28,7 +28,7 @@
     </blockquote>
     {% if source_name %}
       <figcaption class="row">
-        <div class="col-lg-4 offset-lg-6">
+        <div class="col-lg-5 offset-lg-6">
           <div class="fw-bold">{{ source_name }}</div>
           {% if source_title %}
             <div>{{ source_title }}</div>


### PR DESCRIPTION
Closes #899 

This PR applies the suggested change to go from `col-lg-4` to `col-lg-5` for the div holding the quote attribution. It works well!

It makes the width match Figma better for not only `/rider-benefits`, but also `/gtfs-realtime` and `/tap-to-pay`.

<details><summary> Screenshots</summary>

`/rider-benefits`

<img width="1680" height="1005" alt="image" src="https://github.com/user-attachments/assets/2549fc64-ec05-43ea-95b4-74cfac9435eb" />

`/gtfs-realtime` and `/tap-to-pay`

| Live | This branch | Figma |
| --- | --- | --- |
| <img width="1680" height="1005" alt="Screenshot from 2026-04-27 13-08-44" src="https://github.com/user-attachments/assets/e21c3d65-db3f-449c-b177-5774de6fbffa" /> | <img width="1680" height="1005" alt="Screenshot from 2026-04-27 13-08-49" src="https://github.com/user-attachments/assets/38a175b6-47e3-4888-be9a-dba7b73c563d" /> | <img width="892" height="1056" alt="Screenshot from 2026-04-27 13-09-16" src="https://github.com/user-attachments/assets/ff07afbf-f7d8-435b-8dbe-34584f796dd1" /> |
| <img width="1680" height="1005" alt="Screenshot from 2026-04-27 13-09-35" src="https://github.com/user-attachments/assets/421aa683-8549-4575-a27c-a491c1da4cc4" /> | <img width="1680" height="1005" alt="Screenshot from 2026-04-27 13-09-37" src="https://github.com/user-attachments/assets/07935cfb-d38e-4c55-b98a-0ed54108e7f0" /> | <img width="892" height="1056" alt="Screenshot from 2026-04-27 13-09-30" src="https://github.com/user-attachments/assets/2cfe9aa2-1916-44a9-8bb6-bbdd64ff685b" /> |

</details>

## Some notes on the target branch

Similar to changes like the ones in #894, #895, #886, this work wasn't exclusively for implementing the Benefits page, but rather was more to fix a discrepancy between what's in prod vs. in Figma that we noticed because we're implementing the Benefits page. However, another way to look at it is the Benefits page implementation could not be complete without fixing those discrepancies.

This makes it ambiguous whether we should target `main` or `feat/rider-benefits`, the "staging" branch we've been working off. I think which one feels more "correct" essentially depends on how you feel about 
- rebasing the staging branch onto `main`
- whether reviewers should be able to see all changes in the staging branch preview site
- whether those discrepancy fixes should be deployed to the live site before the new page

The discussion in https://github.com/cal-itp/mobility-marketplace/pull/894#pullrequestreview-4158175939 adds more context.

It would be great to get consensus about our team philosophy on this sort of branching situation so that in the future we can move more confidently and don't have to try to figure this out on-the-fly. I recall this coming up in the past with websites work, and we've just never really talked through this.

I have this branch targeting `feat/rider-benefits` so that @leelas-pm and @cmajel can review it on the staging branch preview site since this was feedback on the Benefits page.

