### PR TITLE
fix: pass google analytics tag as an explicit string

### DIFF
--- a/src/_layouts/main.html
+++ b/src/_layouts/main.html
@@ -30,8 +30,7 @@
         dataLayer.push(arguments);
       }
       gtag('js', new Date());
-
-      gtag('config', {{ site.google_analytics_id }});
+      gtag('config', '{{ site.google_analytics_id }}');
     </script>
   </head>
   <body>


### PR DESCRIPTION
we were so close!

<img width="534" height="77" alt="Screenshot 2026-04-29 at 1 09 42 PM" src="https://github.com/user-attachments/assets/adcf4a71-a54a-4a86-a098-e0bd1440423a" />
<img width="319" height="66" alt="Screenshot 2026-04-29 at 1 09 49 PM" src="https://github.com/user-attachments/assets/43b18495-a459-4f90-9aad-ce28d4c84947" />
