### PR TITLE
chore: replace deprecated toml vs code extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,12 +18,12 @@
         }
       },
       "extensions": [
-        "bungcip.better-toml",
         "eamodio.gitlens",
         "esbenp.prettier-vscode",
         "mhutchie.git-graph",
         "redhat.vscode-xml",
-        "shopify.theme-check-vscode"
+        "shopify.theme-check-vscode",
+        "tombi-toml.tombi"
       ]
     }
   }


### PR DESCRIPTION
as suggested in https://github.com/cal-itp/mobility-marketplace/pull/912#discussion_r3320733822

<img width="319" height="124" alt="Screenshot 2026-05-28 at 2 51 17 PM" src="https://github.com/user-attachments/assets/a8f7ca92-1e68-44a2-82ad-718490a6bfdb" />

this PR swaps in the same (maintained) .toml extension that @Scotchester landed on in calitp.org.

