### PR TITLE
fix: smooth out VoiceOver reading of numbered headings

### DIFF
--- a/src/demo.liquid
+++ b/src/demo.liquid
@@ -148,6 +148,16 @@ for our small team. We’re able to prioritize GTFS-RT first and foremost before
     </div>
   </div>
 
+  <div class="row">
+    <h2 id="poc">Numbered headings (w/ wrapping <code>&lt;div&gt;</code>)</h2>
+    <div class="offset-lg-2 col-lg-7 col-12">
+      <div class="vo-friendly" data-number="1"><h3>Choose a data plan</h3></div>
+      <div class="vo-friendly purple" data-number="2"><h3>Review purchase options</h3></div>
+      <div class="vo-friendly cyan-light" data-number="3"><h3>Reach out to your vendor</h3></div>
+      <div class="vo-friendly cyan-dark" data-number="4"><h3>Sign agreement</h3></div>
+    </div>
+  </div>
+
   <h2>Tables</h2>
   <h3>Not responsive, color scheme: yellow</h3>
   <table class="table_yellow my-3">

--- a/src/styles/guide.css
+++ b/src/styles/guide.css
@@ -76,6 +76,45 @@ ul > li:last-child {
   left: calc(-1 * var(--spacing-6));
   line-height: calc(2rem + (1rem / 16));
 }
+
+.vo-friendly::before {
+  display: block;
+  border-radius: 100%;
+  position: absolute;
+  content: attr(data-number);
+  color: var(--dsdl-black);
+  text-align: center;
+  font-family: var(--dsdl-heading-font-stack);
+  font-size: var(--text-xxl);
+  font-weight: bold;
+  width: 1.75em;
+  height: 1.75em;
+  line-height: 1.75em;
+  background-color: var(--calitp-brand-yellow);
+}
+
+.vo-friendly.purple::before {
+  background-color: var(--dsdl-purple-80);
+  color: white;
+}
+
+.vo-friendly.cyan-light::before {
+  background-color: var(--dsdl-cyan-10);
+}
+
+.vo-friendly.cyan-dark::before {
+  background-color: var(--dsdl-cyan-60);
+  color: white;
+}
+
+.vo-friendly h3 {
+  position: relative;
+  padding-top: 0.25em;
+  padding-bottom: 0.25em;
+  padding-left: 2.5em;
+  margin-top: var(--spacing-5);
+}
+
 .numbered::before {
   content: attr(data-number);
   width: 1.75em;


### PR DESCRIPTION
the purpose of this PR is to test another POC related to #906

### Option 1: add a [wrapping `<div>`](https://deploy-preview-929--cal-itp-mobility-marketplace.netlify.app/demo/#poc)

```html
<div data-number="1">
  <h3>Choose a data plan</h3>
</div>
```
with this option, VoiceOver announces each number immediately before reading each heading in both browsers.

since the number is divorced from the actual heading, it is also omitted from the VoiceOver rotor.

https://github.com/user-attachments/assets/5a8654e6-0fa4-407a-8d43-b91f4283b30a

<img width="634" height="905" alt="Screenshot 2026-06-11 at 2 43 15 PM" src="https://github.com/user-attachments/assets/f10b102c-1315-4b98-b6c1-f3bf8ee7d8a5" />

### Option 2: `<h3 role="text">`

the other option we discussed previously in https://github.com/cal-itp/mobility-marketplace/issues/906#issuecomment-4627026828, 👇 would smooth out the way the headings are read in VoiceOver + Safari but not VoiceOver + Chrome.

```html
<h3 role="text">
  <span class="numbered-badge">1.</span>
  Choose a data plan
</h3>
```

admittedly neither of the solutions i've come up with are a silver-bullet. i lean slightly toward option 1, but i'm going to tag @Scotchester here too in case he's got a trick up his sleeve or is available to pair on it.