### PR TITLE
fix: use an ordered list to smooth out VoiceOver reading of numbered headings

### DIFF
--- a/src/_layouts/main.liquid
+++ b/src/_layouts/main.liquid
@@ -53,7 +53,7 @@
       <div class="header-wrapper">
         {% include 'header/desktop' %}
         {% include 'header/mobile' %}
-        {% if show_call_to_action %}
+        {% if showCallToAction %}
           {% include 'header/cta-banner.html' %}
         {% endif %}
       </div>

--- a/src/data-plans.liquid
+++ b/src/data-plans.liquid
@@ -44,236 +44,250 @@ connectivity to modernize and improve the rider experience.' %}
 
 <div class="container">
   <h2>Guide to purchase or change data plans</h2>
-  <h3 class="numbered numbered_purple" data-number="1">Choose a data plan</h3>
-  <h4 class="mt-3">Coverage</h4>
-  <p>
-    Check your area’s coverage, as signal strength can vary. The map below shows FCC data on coverage by providers, including
-    AT&T, T-Mobile, Verizon, and FirstNet.
-  </p>
-  <a href="https://broadbandmap.fcc.gov/location-summary/mobile?zoom=4.17&vlon=-117.083903&vlat=40.891704&env=0&tech=tech4g">
-    <img width="100%" src="/uploads/fcc-coverage-map.png" alt="screenshot of FCC coverage map">
-  </a>
-  <p>
-    Visit
-    <a href="https://broadbandmap.fcc.gov/location-summary/mobile?zoom=4.17&vlon=-117.083903&vlat=40.891704&env=0&tech=tech4g"
-      >FCC<span aria-label="(external link)">↗</span></a
-    >
-    or
-    <a href="https://www.firstnet.com/coverage.html">FirstNet<span aria-label="(external link)">↗</span></a>
-    to learn more.
-  </p>
-  <h4 class="mt-3">Hardware</h4>
-  <p>
-    Hardware can greatly influence what carrier network you can use. From routers to CAD/AVL systems, camera feeds to passenger
-    Wi-Fi, digital fare validators to digital signage, and more, ask hardware vendors about their network compatibility.
-  </p>
-  <p>
-    If the hardware you plan to or have purchased is not certified or compatible to use a SIM on your desired network, you can use
-    a router to connect devices via Wi-Fi. There is a higher upfront cost to purchase a router, but it can greatly reduce
-    certification frustration down the road.
-  </p>
-  <p>
-    Some agencies opt to use multi-SIM to have a fallback across multiple carriers; check that your hardware can support
-    multicarriers. Data prices for primary and secondary coverage are negotiable.
-  </p>
-  <h4 class="mt-3">Data estimation</h4>
-  <p>
-    How much data you use depends on how many devices are on each vehicle. Typical usage for GTFS software and one fare payment
-    validator is 2 GB/month.
-  </p>
-  {% include 'usage-estimator' %}
-  <h4 class="mt-3">Funding</h4>
-  <p>
-    You may use funding from various sources to complete this purchase, including the
-    <a href="https://www.transit.dot.gov/funding/grants/grant-programs">FTA<span aria-label="(external link)">↗</span></a
-    >, <a href="https://dot.ca.gov/">Caltrans<span aria-label="(external link)">↗</span></a
-    >, and other sources of local and state public funding. You are encouraged to confirm that your funds are eligible to be used
-    for this purchase prior to finalizing the contract.
-  </p>
-  <h3 class="numbered numbered_purple" data-number="2">Review purchase options</h3>
-  <p>
-    Both CALNET and NASPO Agreement and Participating Addendum are standardized and allow you to purchase select goods directly
-    without additional competitive bidding, including but not limited to purchasing more SIMs from a current vendor, switching to
-    another plan, or switching to another vendor.
-  </p>
-  <h4 id="contracts" class="mt-3">Data plans MSAs</h4>
-  <p>Cost per month per vehicle, prices are negotiable</p>
-  <div class="table-responsive my-3">
-    <table class="table_purple mb-2">
-      <thead>
-        <tr>
-          <th scope="row">MSAs</th>
-          <th colspan="3" scope="col">
-            <a href="https://cdt.ca.gov/services/calnet-calitp/">CALNET</a> +
-            <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
-              >NASPO</a
-            >
-          </th>
-          <th scope="col">
-            <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
-              >NASPO</a
-            >
-          </th>
-        </tr>
-        <tr>
-          <th scope="row">Vendors</th>
-          <th scope="col">AT&T</th>
-          <th scope="col" class="text-nowrap">T-Mobile</th>
-          <th scope="col">Verizon</th>
-          <th scope="col">FirstNet</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">1 GB</th>
-          <td>$20</td>
-          <td>$8</td>
-          <td>$15</td>
-          <td>$7.50</td>
-        </tr>
-        <tr>
-          <th scope="row">2 GB</th>
-          <td>$23</td>
-          <td>$10</td>
-          <td>$20</td>
-          <td>–</td>
-        </tr>
-        <tr>
-          <th scope="row">3 GB</th>
-          <td>–</td>
-          <td>–</td>
-          <td>–</td>
-          <td>$20</td>
-        </tr>
-        <tr>
-          <th scope="row">5 GB</th>
-          <td>$28</td>
-          <td>$21.21</td>
-          <td>$25</td>
-          <td>–</td>
-        </tr>
-        <tr>
-          <th scope="row">25 GB</th>
-          <td>–</td>
-          <td>–</td>
-          <td>–</td>
-          <td>$34</td>
-        </tr>
-        <tr>
-          <th scope="row">Unlimited</th>
-          <td>$50</td>
-          <td>–</td>
-          <td>$34.99</td>
-          <td>–</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <p class="table-caption">Click on each MSA for terms and conditions.</p>
-  <h3 class="numbered numbered_purple" data-number="3">Reach out to your vendor</h3>
-  <p>Reach out to the vendor you’d like to work with. Share your agency goals, hardware, and desired data plan.</p>
-  <h4 class="mt-3">CALNET</h4>
-  <p>
-    <b>AT&T:</b> Aaron Rollins<br>
-    <a href="mailto:ar5941@att.com">ar5941@att.com</a>, (916) 837-9795
-  </p>
-  <p>
-    <b>T-Mobile:</b> Lindsey Shaw<br>
-    <a href="mailto:Lindsey.Shaw34@t-mobile.com">Lindsey.Shaw34@t-mobile.com</a>, (916) 674-0526
-  </p>
-  <p>
-    <b>Verizon:</b> Melissa Togo<br>
-    <a href="mailto:melissa.togo@verizonwireless.com">melissa.togo@verizonwireless.com</a>, (949) 233-1282
-  </p>
-  <h5>Complete the NESPA</h5>
-  <p>
-    Self-certify that your organization qualifies for CALNET eligibility. All non-state government entities must complete a
-    <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2025/04/CALNET_CALNET-NESPA-10.22_KO1.pdf"
-      >Non-State Entity Service Policy and Agreement (NESPA)<span aria-label="(external link)">↗</span></a
-    >. Submit completed NESPA forms to <a href="mailto:calnethelp@state.ca.gov">calnethelp@state.ca.gov</a> and cc
-    <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">hello@calitp.org</a>.
-  </p>
-  <p>
-    Need help with the NESPA or unsure if you need one? Reach out at
-    <a href="mailto:calnethelp@state.ca.gov">calnethelp@state.ca.gov</a> or call (916) 657-9150.
-  </p>
-  <h4 class="mt-3">FirstNet</h4>
-  <p>
-    <b>FirstNet:</b> Brett Perez<br>
-    <a href="mailto:Brett.Perez@att.com">Brett.Perez@att.com</a>, (512) 656-2331
-  </p>
-  <p>
-    FirstNet’s account managers can help you determine how many SIMs you need to purchase. This process from interest to launch
-    typically takes 14 weeks.
-  </p>
-  <p>
-    If your device is not eligible for FirstNet, you may still be able to get the same rates on the commercial AT&T network.
-    Please contact the FirstNet representatives above to learn more.
-  </p>
-  <h3 class="numbered numbered_purple" data-number="4">Sign agreement</h3>
-  <h4 class="mt-3">CALNET</h4>
-  <h5>Complete Authorization to Order</h5>
-  <p>
-    After you’ve selected your vendor and signed the NESPA, you’re ready to order. To use a CALNET contract, you must have an
-    Authorization to Order (ATO) form on file with the CALNET Program. Each contractor has a unique ATO:
-  </p>
-  <ul>
+  <ol class="numbered-list numbered-list_purple">
     <li>
-      <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2026/01/CALNET-ATT-CAT191-ATO-Form-A11Y.pdf"
-        >AT&T<span aria-label="(external link)">↗</span></a
-      >
+      <h3>Choose a data plan</h3>
+      <h4 class="mt-3">Coverage</h4>
+      <p>
+        Check your area’s coverage, as signal strength can vary. The map below shows FCC data on coverage by providers, including
+        AT&T, T-Mobile, Verizon, and FirstNet.
+      </p>
+      <a href="https://broadbandmap.fcc.gov/location-summary/mobile?zoom=4.17&vlon=-117.083903&vlat=40.891704&env=0&tech=tech4g">
+        <img width="100%" src="/uploads/fcc-coverage-map.png" alt="screenshot of FCC coverage map">
+      </a>
+      <p>
+        Visit
+        <a href="https://broadbandmap.fcc.gov/location-summary/mobile?zoom=4.17&vlon=-117.083903&vlat=40.891704&env=0&tech=tech4g"
+          >FCC<span aria-label="(external link)">↗</span></a
+        >
+        or
+        <a href="https://www.firstnet.com/coverage.html">FirstNet<span aria-label="(external link)">↗</span></a>
+        to learn more.
+      </p>
+      <h4 class="mt-3">Hardware</h4>
+      <p>
+        Hardware can greatly influence what carrier network you can use. From routers to CAD/AVL systems, camera feeds to
+        passenger Wi-Fi, digital fare validators to digital signage, and more, ask hardware vendors about their network
+        compatibility.
+      </p>
+      <p>
+        If the hardware you plan to or have purchased is not certified or compatible to use a SIM on your desired network, you can
+        use a router to connect devices via Wi-Fi. There is a higher upfront cost to purchase a router, but it can greatly reduce
+        certification frustration down the road.
+      </p>
+      <p>
+        Some agencies opt to use multi-SIM to have a fallback across multiple carriers; check that your hardware can support
+        multicarriers. Data prices for primary and secondary coverage are negotiable.
+      </p>
+      <h4 class="mt-3">Data estimation</h4>
+      <p>
+        How much data you use depends on how many devices are on each vehicle. Typical usage for GTFS software and one fare
+        payment validator is 2 GB/month.
+      </p>
+      {% include 'usage-estimator' %}
+      <h4 class="mt-3">Funding</h4>
+      <p>
+        You may use funding from various sources to complete this purchase, including the
+        <a href="https://www.transit.dot.gov/funding/grants/grant-programs">FTA<span aria-label="(external link)">↗</span></a
+        >, <a href="https://dot.ca.gov/">Caltrans<span aria-label="(external link)">↗</span></a
+        >, and other sources of local and state public funding. You are encouraged to confirm that your funds are eligible to be
+        used for this purchase prior to finalizing the contract.
+      </p>
     </li>
     <li>
-      <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2025/04/CALNET-TMobile-CAT191-ATO-Form-A11Y.pdf"
-        >T-Mobile<span aria-label="(external link)">↗</span></a
-      >
+      <h3>Review purchase options</h3>
+      <p>
+        Both CALNET and NASPO Agreement and Participating Addendum are standardized and allow you to purchase select goods
+        directly without additional competitive bidding, including but not limited to purchasing more SIMs from a current vendor,
+        switching to another plan, or switching to another vendor.
+      </p>
+      <h4 id="contracts" class="mt-3">Data plans MSAs</h4>
+      <p>Cost per month per vehicle, prices are negotiable</p>
+      <div class="table-responsive my-3">
+        <table class="table_purple mb-2">
+          <thead>
+            <tr>
+              <th scope="row">MSAs</th>
+              <th colspan="3" scope="col">
+                <a href="https://cdt.ca.gov/services/calnet-calitp/">CALNET</a> +
+                <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
+                  >NASPO</a
+                >
+              </th>
+              <th scope="col">
+                <a href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf"
+                  >NASPO</a
+                >
+              </th>
+            </tr>
+            <tr>
+              <th scope="row">Vendors</th>
+              <th scope="col">AT&T</th>
+              <th scope="col" class="text-nowrap">T-Mobile</th>
+              <th scope="col">Verizon</th>
+              <th scope="col">FirstNet</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">1 GB</th>
+              <td>$20</td>
+              <td>$8</td>
+              <td>$15</td>
+              <td>$7.50</td>
+            </tr>
+            <tr>
+              <th scope="row">2 GB</th>
+              <td>$23</td>
+              <td>$10</td>
+              <td>$20</td>
+              <td>–</td>
+            </tr>
+            <tr>
+              <th scope="row">3 GB</th>
+              <td>–</td>
+              <td>–</td>
+              <td>–</td>
+              <td>$20</td>
+            </tr>
+            <tr>
+              <th scope="row">5 GB</th>
+              <td>$28</td>
+              <td>$21.21</td>
+              <td>$25</td>
+              <td>–</td>
+            </tr>
+            <tr>
+              <th scope="row">25 GB</th>
+              <td>–</td>
+              <td>–</td>
+              <td>–</td>
+              <td>$34</td>
+            </tr>
+            <tr>
+              <th scope="row">Unlimited</th>
+              <td>$50</td>
+              <td>–</td>
+              <td>$34.99</td>
+              <td>–</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="table-caption">Click on each MSA for terms and conditions.</p>
     </li>
     <li>
-      <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2025/04/CALNET-Verizon-CAT191-ATO-Form-A11Y.pdf"
-        >Verizon<span aria-label="(external link)">↗</span></a
-      >
+      <h3>Reach out to your vendor</h3>
+      <p>Reach out to the vendor you’d like to work with. Share your agency goals, hardware, and desired data plan.</p>
+      <h4 class="mt-3">CALNET</h4>
+      <p>
+        <b>AT&T:</b> Aaron Rollins<br>
+        <a href="mailto:ar5941@att.com">ar5941@att.com</a>, (916) 837-9795
+      </p>
+      <p>
+        <b>T-Mobile:</b> Lindsey Shaw<br>
+        <a href="mailto:Lindsey.Shaw34@t-mobile.com">Lindsey.Shaw34@t-mobile.com</a>, (916) 674-0526
+      </p>
+      <p>
+        <b>Verizon:</b> Melissa Togo<br>
+        <a href="mailto:melissa.togo@verizonwireless.com">melissa.togo@verizonwireless.com</a>, (949) 233-1282
+      </p>
+      <h5>Complete the NESPA</h5>
+      <p>
+        Self-certify that your organization qualifies for CALNET eligibility. All non-state government entities must complete a
+        <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2025/04/CALNET_CALNET-NESPA-10.22_KO1.pdf"
+          >Non-State Entity Service Policy and Agreement (NESPA)<span aria-label="(external link)">↗</span></a
+        >. Submit completed NESPA forms to <a href="mailto:calnethelp@state.ca.gov">calnethelp@state.ca.gov</a> and cc
+        <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">hello@calitp.org</a>.
+      </p>
+      <p>
+        Need help with the NESPA or unsure if you need one? Reach out at
+        <a href="mailto:calnethelp@state.ca.gov">calnethelp@state.ca.gov</a> or call (916) 657-9150.
+      </p>
+      <h4 class="mt-3">FirstNet</h4>
+      <p>
+        <b>FirstNet:</b> Brett Perez<br>
+        <a href="mailto:Brett.Perez@att.com">Brett.Perez@att.com</a>, (512) 656-2331
+      </p>
+      <p>
+        FirstNet’s account managers can help you determine how many SIMs you need to purchase. This process from interest to
+        launch typically takes 14 weeks.
+      </p>
+      <p>
+        If your device is not eligible for FirstNet, you may still be able to get the same rates on the commercial AT&T network.
+        Please contact the FirstNet representatives above to learn more.
+      </p>
     </li>
-  </ul>
-  <p>Once the ATO is complete, email it to your vendor.</p>
-  <h5>Submit purchase order</h5>
-  <p>
-    Submit a purchase order directly to your vendor, in accordance with their own procurement rules. You may use the
-    <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2024/08/CALNET_Form-20_20230504_A11Y.pdf"
-      >CALNET ordering Form<span aria-label="(external link)">↗</span></a
-    >&thinsp;(<a
-      href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2023/09/CALNET_Form-20_Instructions_20230504_A11Y.pdf"
-      >instructions<span aria-label="(external link)">↗</span></a
-    >)
-  </p>
-  <h4 class="mt-3">FirstNet</h4>
-  <p>Send your request to order via email, including the following information:</p>
-  <ul>
-    <li>Contacts information (name, phone, email)</li>
-    <li>Shipping address</li>
-    <li>Anticipated device use case</li>
-    <li>Device information (device type, model, and SIM size)</li>
-    <li>Quantity of SIMs desired</li>
-    <li>Data plan size desired</li>
-    <li>Go live target date, if applicable</li>
-  </ul>
-  <p>
-    FirstNet will then provide you with a SIM purchasing and use contract. This contract serves as an addendum to the
-    <a
-      href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf?__hstc=108482141.eb28f040f78da06d6407fceb2dbe3f17.1755810960028.1761166975290.1761169621963.46&__hssc=108482141.3.1761169621963&__hsfp=639139624"
-      >National Association of State Procurement Officials (NASPO) Agreement</a
-    >
-    #MA149.
-  </p>
-  <p>Review, sign, and send the contract to your FirstNet account manager.</p>
-  <h3 class="numbered numbered_purple" data-number="5">Implement and launch</h3>
-  <p>
-    Once you’ve completed your order form, your new carrier will set up a device management portal. Depending on your carrier, you
-    may be able to order your SIMs directly from this portal. Be sure to coordinate installation with your hardware provider,
-    especially for PADs, as they may want to install SIMs in the devices.
-  </p>
-  <p>
-    If switching carriers, be sure to align your previous contract end and new provider start dates so you do not lose coverage.
-  </p>
+    <li>
+      <h3>Sign agreement</h3>
+      <h4 class="mt-3">CALNET</h4>
+      <h5>Complete Authorization to Order</h5>
+      <p>
+        After you’ve selected your vendor and signed the NESPA, you’re ready to order. To use a CALNET contract, you must have an
+        Authorization to Order (ATO) form on file with the CALNET Program. Each contractor has a unique ATO:
+      </p>
+      <ul>
+        <li>
+          <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2026/01/CALNET-ATT-CAT191-ATO-Form-A11Y.pdf"
+            >AT&T<span aria-label="(external link)">↗</span></a
+          >
+        </li>
+        <li>
+          <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2025/04/CALNET-TMobile-CAT191-ATO-Form-A11Y.pdf"
+            >T-Mobile<span aria-label="(external link)">↗</span></a
+          >
+        </li>
+        <li>
+          <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2025/04/CALNET-Verizon-CAT191-ATO-Form-A11Y.pdf"
+            >Verizon<span aria-label="(external link)">↗</span></a
+          >
+        </li>
+      </ul>
+      <p>Once the ATO is complete, email it to your vendor.</p>
+      <h5>Submit purchase order</h5>
+      <p>
+        Submit a purchase order directly to your vendor, in accordance with their own procurement rules. You may use the
+        <a href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2024/08/CALNET_Form-20_20230504_A11Y.pdf"
+          >CALNET ordering Form<span aria-label="(external link)">↗</span></a
+        >&thinsp;(<a
+          href="https://cdt.ca.gov/services/wp-content/uploads/sites/2/2023/09/CALNET_Form-20_Instructions_20230504_A11Y.pdf"
+          >instructions<span aria-label="(external link)">↗</span></a
+        >)
+      </p>
+      <h4 class="mt-3">FirstNet</h4>
+      <p>Send your request to order via email, including the following information:</p>
+      <ul>
+        <li>Contacts information (name, phone, email)</li>
+        <li>Shipping address</li>
+        <li>Anticipated device use case</li>
+        <li>Device information (device type, model, and SIM size)</li>
+        <li>Quantity of SIMs desired</li>
+        <li>Data plan size desired</li>
+        <li>Go live target date, if applicable</li>
+      </ul>
+      <p>
+        FirstNet will then provide you with a SIM purchasing and use contract. This contract serves as an addendum to the
+        <a
+          href="https://resources.calitp.org/mobility-marketplace/State.of.California_Amendment.1_Extension.2023-05.pdf?__hstc=108482141.eb28f040f78da06d6407fceb2dbe3f17.1755810960028.1761166975290.1761169621963.46&__hssc=108482141.3.1761169621963&__hsfp=639139624"
+          >National Association of State Procurement Officials (NASPO) Agreement</a
+        >
+        #MA149.
+      </p>
+      <p>Review, sign, and send the contract to your FirstNet account manager.</p>
+    </li>
+    <li>
+      <h3>Implement and launch</h3>
+      <p>
+        Once you’ve completed your order form, your new carrier will set up a device management portal. Depending on your carrier,
+        you may be able to order your SIMs directly from this portal. Be sure to coordinate installation with your hardware
+        provider, especially for PADs, as they may want to install SIMs in the devices.
+      </p>
+      <p>
+        If switching carriers, be sure to align your previous contract end and new provider start dates so you do not lose
+        coverage.
+      </p>
+    </li>
+  </ol>
   <h2 class="pt-5 mt-2 mt-md-3">Additional info</h2>
   <h3 class="mt-0">Commonly asked questions</h3>
   <h4 class="mt-0">What is FirstNet? Why am I on commercial versus Band 14?</h4>

--- a/src/demo.liquid
+++ b/src/demo.liquid
@@ -1,13 +1,13 @@
 ---
 layout: main
 stylesheet: guide.css
-
 title: Component demo
-description: >
-  A page to view individual layout components as they are completed
+description: A page to view individual layout components as they are completed
 dummyTags: ["GTFS-RT"]
 noindex: true
 show_call_to_action: true
+colorSchemes: ['yellow','purple','green','cyan-light','cyan-dark']
+
 ---
 <div class="container">
   <h1>DSDL component demo</h1>
@@ -77,74 +77,45 @@ for our small team. We’re able to prioritize GTFS-RT first and foremost before
 
 <div class="container">
   <h2>Step list</h2>
-  <div class="row">
-    <h3>Color scheme: yellow</h3>
-    <div class="offset-lg-2 col-lg-7 col-12">
-      <ol class="step-list step-list_yellow my-4">
-        <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
-        <li>
-          <b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on
-          <a href="#">CALNET</a> or on <a href="#">NASPO</a>
-        </li>
-        <li><b>Engage the vendor</b> you’d like to purchase from</li>
-        <li><b>Sign the agreement</b></li>
-        <li><b>Implement and launch,</b> be sure to coordinate with your hardware providers to align on who will install SIMs</li>
-      </ol>
+  {% for color in colorSchemes %}
+    <div class="row">
+      <h3>
+        Color scheme: <code>{{ color }}</code>
+      </h3>
+      <div class="offset-lg-2 col-lg-7 col-12">
+        <ol class="step-list step-list_{{color}} my-4">
+          <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
+          <li>
+            <b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on
+            <a href="#">CALNET</a> or on <a href="#">NASPO</a>
+          </li>
+          <li><b>Engage the vendor</b> you’d like to purchase from</li>
+          <li><b>Sign the agreement</b></li>
+          <li>
+            <b>Implement and launch,</b> be sure to coordinate with your hardware providers to align on who will install SIMs
+          </li>
+        </ol>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <h3>Color scheme: purple</h3>
-    <div class="offset-lg-2 col-lg-7 col-12">
-      <ol class="step-list step-list_purple my-4">
-        <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
-        <li>
-          <b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on
-          <a href="#">CALNET</a> or on <a href="#">NASPO</a>
-        </li>
-        <li><b>Engage the vendor</b> you’d like to purchase from</li>
-        <li><b>Sign the agreement</b></li>
-        <li><b>Implement and launch,</b> be sure to coordinate with your hardware providers to align on who will install SIMs</li>
-      </ol>
-    </div>
-  </div>
-  <div class="row">
-    <h3>Color scheme: cyan-light</h3>
-    <div class="offset-lg-2 col-lg-7 col-12">
-      <ol class="step-list step-list_cyan-light my-4">
-        <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
-        <li>
-          <b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on
-          <a href="#">CALNET</a> or on <a href="#">NASPO</a>
-        </li>
-        <li><b>Engage the vendor</b> you’d like to purchase from</li>
-        <li><b>Sign the agreement</b></li>
-        <li><b>Implement and launch,</b> be sure to coordinate with your hardware providers to align on who will install SIMs</li>
-      </ol>
-    </div>
-  </div>
-  <div class="row">
-    <h3>Color scheme: cyan-dark</h3>
-    <div class="offset-lg-2 col-lg-7 col-12">
-      <ol class="step-list step-list_cyan-dark my-4">
-        <li><b>Choose a data-only provider</b> and plan that fits your agency’s needs</li>
-        <li>
-          <b>Review purchase options:</b> You can access data plans in the commercial marketplace or at discounted rates on
-          <a href="#">CALNET</a> or on <a href="#">NASPO</a>
-        </li>
-        <li><b>Engage the vendor</b> you’d like to purchase from</li>
-        <li><b>Sign the agreement</b></li>
-        <li><b>Implement and launch,</b> be sure to coordinate with your hardware providers to align on who will install SIMs</li>
-      </ol>
-    </div>
-  </div>
+  {% endfor %}
 
   <div class="row">
-    <h2>Numbered headings</h2>
+    <h2 id="numbered-headings">Numbered headings</h2>
     <div class="offset-lg-2 col-lg-7 col-12">
-      <h3 class="numbered numbered_yellow" data-number="1">Choose a data plan</h3>
-      <h3 class="numbered numbered_purple" data-number="2">Review purchase options</h3>
-      <h3 class="numbered numbered_cyan-light" data-number="3">Reach out to your vendor</h3>
-      <h3 class="numbered numbered_cyan-dark" data-number="4">Sign agreement</h3>
+      <ol class="numbered-list numbered-list_yellow">
+        <li>
+          <h3>Choose a data plan</h3>
+        </li>
+        <li>
+          <h3>Review purchase options</h3>
+        </li>
+        <li>
+          <h3>Reach out to your vendor</h3>
+        </li>
+        <li>
+          <h3>Sign agreement</h3>
+        </li>
+      </ol>
     </div>
   </div>
 

--- a/src/demo.liquid
+++ b/src/demo.liquid
@@ -5,7 +5,7 @@ title: Component demo
 description: A page to view individual layout components as they are completed
 dummyTags: ["GTFS-RT"]
 noindex: true
-show_call_to_action: true
+showCallToAction: true
 colorSchemes: ['yellow','purple','green','cyan-light','cyan-dark']
 
 ---

--- a/src/gtfs-realtime.liquid
+++ b/src/gtfs-realtime.liquid
@@ -49,209 +49,223 @@ for our small team. We’re able to prioritize GTFS-RT first and foremost before
 
 <div class="container">
   <h2>Agency guide for real-time data</h2>
-  <h3 class="numbered numbered_cyan-light" data-number="1">Assemble your basics</h3>
-  <p>Confirm your current GTFS Schedule feed is correct and up-to-date.</p>
-  <ul>
+  <ol class="numbered-list numbered-list_cyan-light">
     <li>
-      If you do not have a GTFS Schedule feed, please
-      <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">reach out</a> to discuss your options. If you need
-      educational information to share with your staff or board of directors, please review the
-      <a href="/gtfs-intro">Introduction to GTFS</a>
+      <h3>Assemble your basics</h3>
+      <p>Confirm your current GTFS Schedule feed is correct and up-to-date.</p>
+      <ul>
+        <li>
+          If you do not have a GTFS Schedule feed, please
+          <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">reach out</a> to discuss your options. If you
+          need educational information to share with your staff or board of directors, please review the
+          <a href="/gtfs-intro">Introduction to GTFS</a>
+        </li>
+        <li>If you have a Schedule feed, Cal-ITP provides monthly data quality reports.</li>
+      </ul>
+      <p>
+        Check your fleet’s internet connectivity; a data connection is required, and you may need to upgrade existing data plans.
+      </p>
+      <ul>
+        <li>
+          Check out the <a href="/data-plans">pre-negotiated data plans</a> your agency may be eligible to upgrade and save on
+          monthly costs.
+        </li>
+      </ul>
+      <p>Check with your funding agencies.</p>
+      <ul>
+        <li>
+          Projects from these MSAs may be funded through grants from the
+          <a href="https://www.transit.dot.gov/funding/grants/grant-programs">FTA<span aria-label="(external link)">↗</span></a
+          >, <a href="https://dot.ca.gov/">Caltrans<span aria-label="(external link)">↗</span></a
+          >, and other sources of local and state public funding.
+        </li>
+      </ul>
+      <p>
+        <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">Connect</a> with an Cal-ITP Account Manager for
+        guided GTFS Realtime support
+      </p>
     </li>
-    <li>If you have a Schedule feed, Cal-ITP provides monthly data quality reports.</li>
-  </ul>
-  <p>Check your fleet’s internet connectivity; a data connection is required, and you may need to upgrade existing data plans.</p>
-  <ul>
     <li>
-      Check out the <a href="/data-plans">pre-negotiated data plans</a> your agency may be eligible to upgrade and save on monthly
-      costs.
+      <h3>Understand purchase options</h3>
+      <h4 class="mt-3">How to buy off the pre-procured bench</h4>
+      <p>
+        California offers 3 MSAs (Master Service Agreements) that make it easy to purchase GTFS Realtime software (and optional
+        hardware) without doing your own procurement. You can purchase through these agreements and negotiate the best prices for
+        your agency.
+      </p>
+      <p>All contracts include:</p>
+      <ul>
+        <li>Creation of GTFS Realtime feeds</li>
+        <li>Integration into up to 3 journey planning apps (i.e. Google Maps, Transit App, Apple Maps, etc.)</li>
+        <li>Optional hardware for purchase*</li>
+      </ul>
+      <p>
+        *Hardware is necessary to enable software services, however transit providers may choose to either use their own hardware
+        or purchase devices through the MSA
+      </p>
+      <h4 id="contracts" class="mt-3">GTFS Realtime MSAs</h4>
+      <p class="table-caption">Click on each MSA for terms and conditions.</p>
+      <div class="table-responsive my-3">
+        <table class="table_cyan mb-2">
+          <thead>
+            <tr>
+              <th scope="col">MSA vendors</th>
+              <th scope="col">MSAs</th>
+              <th scope="col">Pricing structure</th>
+              <th scope="col">Hardware options**</th>
+              <th scope="col">Eligible networks</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Connexionz Ltd</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3"
+                  >5-24-70-42-01</a
+                >
+              </td>
+              <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+              <td>Cellular routing kit (with Pepwave MAX BR1 Mini)</td>
+              <td>
+                <ul>
+                  <li>WiFi</li>
+                  <li>AT&T</li>
+                  <li class="text-nowrap">T-Mobile</li>
+                  <li>Verizon</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>Passio Technologies LLC</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02"
+                  >5-24-70-42-02</a
+                >
+              </td>
+              <td>Base fee + variable fees based on EITHER vehicles or routes</td>
+              <td>
+                <ul>
+                  <li>Calamp LMU-3641</li>
+                  <li>Lilliput RT-V7000 Pro</li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li>WiFi</li>
+                  <li>AT&T</li>
+                  <li class="text-nowrap">T-Mobile</li>
+                  <li>Verizon</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th rowspan="2" style="border-bottom: none">Swiftly Inc</th>
+              <td rowspan="2" style="border-bottom: none">
+                <a
+                  href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2"
+                  >5-24-70-42-03</a
+                >
+              </td>
+              <td rowspan="2" style="border-bottom: none">Variable fees based on number of vehicles</td>
+              <td>Samsara VG55</td>
+              <td>
+                <ul>
+                  <li>WiFi</li>
+                  <li>AT&T</li>
+                  <li>FirstNet</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              {% comment %} part of above Swiftly row; classes compensate for sticky first cell styling {% endcomment %}
+              <td class="position-static border-start-0">
+                <ul>
+                  <li>Samsung Tab Active 5</li>
+                  <li>Cradlepoint R1900</li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li>WiFi</li>
+                  <li>AT&T</li>
+                  <li>FirstNet</li>
+                  <li>T-Mobile</li>
+                  <li>Verizon</li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="table-caption">
+        **You can always bring your own hardware. These are simply the options you could purchase through each vendor. Purchase
+        through a vendor includes a 5-year device warranty.
+      </p>
+      <h4 class="mt-3">Draft a Scope of Work (SOW)</h4>
+      <p>
+        Creating a clear, focused SOW will ensure vendors understand your needs. Download and fill in our
+        <a href="/resources/sow-gtfs">SOW template</a>. Be sure to specify your operating goals, technical environment, and any
+        must-have features or services. Your Cal-ITP Account Manager can offer guidance and review your SOW before sending it to
+        vendors.
+      </p>
     </li>
-  </ul>
-  <p>Check with your funding agencies.</p>
-  <ul>
     <li>
-      Projects from these MSAs may be funded through grants from the
-      <a href="https://www.transit.dot.gov/funding/grants/grant-programs">FTA<span aria-label="(external link)">↗</span></a
-      >, <a href="https://dot.ca.gov/">Caltrans<span aria-label="(external link)">↗</span></a
-      >, and other sources of local and state public funding.
+      <h3>Engage vendors</h3>
+      <p>
+        Send your SOW to vendors. We recommend sending the SOW to all MSA-awarded vendors using our
+        <a href="/resources/email-template-gtfs">email template</a>. Their up-to-date contact information can be found in the MSA
+        User Instructions document (vendor links:
+        <a
+          href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-01"
+          >Connexionz Ltd<span aria-label="(external link)">↗</span></a
+        >,
+        <a
+          href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-02&SETID=STATE&VERSION_NBR=2"
+          >Passio Technologies LLC<span aria-label="(external link)">↗</span></a
+        >,
+        <a
+          href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=3"
+          >Swiftly Inc<span aria-label="(external link)">↗</span></a
+        >)
+      </p>
+      <p>Assess proposals and negotiate as needed; don’t be afraid to ask questions or request changes.</p>
     </li>
-  </ul>
-  <p>
-    <a href="mailto:hello@calitp.org" aria-label="hello at cal i t p dot org">Connect</a> with an Cal-ITP Account Manager for
-    guided GTFS Realtime support
-  </p>
-  <h3 class="numbered numbered_cyan-light" data-number="2">Understand purchase options</h3>
-  <h4 class="mt-3">How to buy off the pre-procured bench</h4>
-  <p>
-    California offers 3 MSAs (Master Service Agreements) that make it easy to purchase GTFS Realtime software (and optional
-    hardware) without doing your own procurement. You can purchase through these agreements and negotiate the best prices for your
-    agency.
-  </p>
-  <p>All contracts include:</p>
-  <ul>
-    <li>Creation of GTFS Realtime feeds</li>
-    <li>Integration into up to 3 journey planning apps (i.e. Google Maps, Transit App, Apple Maps, etc.)</li>
-    <li>Optional hardware for purchase*</li>
-  </ul>
-  <p>
-    *Hardware is necessary to enable software services, however transit providers may choose to either use their own hardware or
-    purchase devices through the MSA
-  </p>
-  <h4 id="contracts" class="mt-3">GTFS Realtime MSAs</h4>
-  <p class="table-caption">Click on each MSA for terms and conditions.</p>
-  <div class="table-responsive my-3">
-    <table class="table_cyan mb-2">
-      <thead>
-        <tr>
-          <th scope="col">MSA vendors</th>
-          <th scope="col">MSAs</th>
-          <th scope="col">Pricing structure</th>
-          <th scope="col">Hardware options**</th>
-          <th scope="col">Eligible networks</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th>Connexionz Ltd</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-01&SETID=STATE&VERSION_NBR=3"
-              >5-24-70-42-01</a
-            >
-          </td>
-          <td>Base fee + variable fees based on EITHER vehicles or routes</td>
-          <td>Cellular routing kit (with Pepwave MAX BR1 Mini)</td>
-          <td>
-            <ul>
-              <li>WiFi</li>
-              <li>AT&T</li>
-              <li class="text-nowrap">T-Mobile</li>
-              <li>Verizon</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th>Passio Technologies LLC</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-02"
-              >5-24-70-42-02</a
-            >
-          </td>
-          <td>Base fee + variable fees based on EITHER vehicles or routes</td>
-          <td>
-            <ul>
-              <li>Calamp LMU-3641</li>
-              <li>Lilliput RT-V7000 Pro</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>WiFi</li>
-              <li>AT&T</li>
-              <li class="text-nowrap">T-Mobile</li>
-              <li>Verizon</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th rowspan="2" style="border-bottom: none">Swiftly Inc</th>
-          <td rowspan="2" style="border-bottom: none">
-            <a
-              href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=2"
-              >5-24-70-42-03</a
-            >
-          </td>
-          <td rowspan="2" style="border-bottom: none">Variable fees based on number of vehicles</td>
-          <td>Samsara VG55</td>
-          <td>
-            <ul>
-              <li>WiFi</li>
-              <li>AT&T</li>
-              <li>FirstNet</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          {% comment %} part of above Swiftly row; classes compensate for sticky first cell styling {% endcomment %}
-          <td class="position-static border-start-0">
-            <ul>
-              <li>Samsung Tab Active 5</li>
-              <li>Cradlepoint R1900</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>WiFi</li>
-              <li>AT&T</li>
-              <li>FirstNet</li>
-              <li>T-Mobile</li>
-              <li>Verizon</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <p class="table-caption">
-    **You can always bring your own hardware. These are simply the options you could purchase through each vendor. Purchase
-    through a vendor includes a 5-year device warranty.
-  </p>
-  <h4 class="mt-3">Draft a Scope of Work (SOW)</h4>
-  <p>
-    Creating a clear, focused SOW will ensure vendors understand your needs. Download and fill in our
-    <a href="/resources/sow-gtfs">SOW template</a>. Be sure to specify your operating goals, technical environment, and any
-    must-have features or services. Your Cal-ITP Account Manager can offer guidance and review your SOW before sending it to
-    vendors.
-  </p>
-  <h3 class="numbered numbered_cyan-light" data-number="3">Engage vendors</h3>
-  <p>
-    Send your SOW to vendors. We recommend sending the SOW to all MSA-awarded vendors using our
-    <a href="/resources/email-template-gtfs">email template</a>. Their up-to-date contact information can be found in the MSA User
-    Instructions document (vendor links:
-    <a
-      href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-24-70-42-01"
-      >Connexionz Ltd<span aria-label="(external link)">↗</span></a
-    >,
-    <a
-      href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-02&SETID=STATE&VERSION_NBR=2"
-      >Passio Technologies LLC<span aria-label="(external link)">↗</span></a
-    >,
-    <a
-      href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=5-24-70-42-03&SETID=STATE&VERSION_NBR=3"
-      >Swiftly Inc<span aria-label="(external link)">↗</span></a
-    >)
-  </p>
-  <p>Assess proposals and negotiate as needed; don’t be afraid to ask questions or request changes.</p>
-  <h3 class="numbered numbered_cyan-light" data-number="4">Sign your user agreement</h3>
-  <p>
-    Once you’ve selected the winning proposal, you and the MSA vendor must execute a User Agreement including the SOW, agreed
-    pricing, and referencing the MSA terms. You can use a Standard Agreement such as
-    <a
-      href="https://www.dgs.ca.gov/ols/Forms?search=213&topicCategoryFilters=&audienceCategoryFilters=9048d318e266493abfd2361dc40d1f45&sort=relevance&activeFilters=audience%7C&page=1"
-      >STD 213 for DGS<span aria-label="(external link)">↗</span></a
-    >
-    or <a href="/resources/user-agreement-gtfs">Sample User Agreement</a>.
-  </p>
-  <p>
-    The User Agreement references the terms of the MSA and allows items to be specified, for example, you can modify the default
-    SLAs/KPIs. The term of the MSAs is for 3 years, with the option to extend for 2-year periods twice.
-  </p>
-  <h3 class="numbered numbered_cyan-light" data-number="5">Get ready to launch</h3>
-  <p>
-    Work closely with your vendor to implement and begin generating real-time data. If technical or practical issues arise,
-    dedicated support channels are available for ongoing troubleshooting.
-  </p>
-  <p>
-    Your User Agreement will contain SLAs/KPIs. If the vendor is unable to meet the SLAs/KPIs or the completion of Project
-    Implementation Plans is late, it may trigger service credits for you.
-  </p>
-  <h4 class="mt-3">Tell your riders</h4>
-  <p>
-    Share the exciting news with your riders and community. Consider reaching out to local press or
-    <a href="https://cal.streetsblog.org/">Streetsblog<span aria-label="(external link)">↗</span></a
-    >. Take a moment to celebrate the hard work of launching GTFS Realtime!
-  </p>
+    <li>
+      <h3>Sign your user agreement</h3>
+      <p>
+        Once you’ve selected the winning proposal, you and the MSA vendor must execute a User Agreement including the SOW, agreed
+        pricing, and referencing the MSA terms. You can use a Standard Agreement such as
+        <a
+          href="https://www.dgs.ca.gov/ols/Forms?search=213&topicCategoryFilters=&audienceCategoryFilters=9048d318e266493abfd2361dc40d1f45&sort=relevance&activeFilters=audience%7C&page=1"
+          >STD 213 for DGS<span aria-label="(external link)">↗</span></a
+        >
+        or <a href="/resources/user-agreement-gtfs">Sample User Agreement</a>.
+      </p>
+      <p>
+        The User Agreement references the terms of the MSA and allows items to be specified, for example, you can modify the
+        default SLAs/KPIs. The term of the MSAs is for 3 years, with the option to extend for 2-year periods twice.
+      </p>
+    </li>
+    <li>
+      <h3>Get ready to launch</h3>
+      <p>
+        Work closely with your vendor to implement and begin generating real-time data. If technical or practical issues arise,
+        dedicated support channels are available for ongoing troubleshooting.
+      </p>
+      <p>
+        Your User Agreement will contain SLAs/KPIs. If the vendor is unable to meet the SLAs/KPIs or the completion of Project
+        Implementation Plans is late, it may trigger service credits for you.
+      </p>
+      <h4 class="mt-3">Tell your riders</h4>
+      <p>
+        Share the exciting news with your riders and community. Consider reaching out to local press or
+        <a href="https://cal.streetsblog.org/">Streetsblog<span aria-label="(external link)">↗</span></a
+        >. Take a moment to celebrate the hard work of launching GTFS Realtime!
+      </p>
+    </li>
+  </ol>
   <h2 class="pt-5 mt-2 mt-md-3">Additional info</h2>
   <h3 class="mt-0">Commonly asked questions</h3>
   <h4 class="mt-0">Do I need any special hardware?</h4>

--- a/src/rider-benefits.liquid
+++ b/src/rider-benefits.liquid
@@ -57,92 +57,100 @@ description: Learn how to set up Cal-ITP Benefits at your transit agency and ext
 <div class="container">
   <h2>How to get started with Cal-ITP Benefits</h2>
 
-  <h3 class="numbered numbered_green" data-number="1">Fill out the onboarding form</h3>
-  <ul>
+  <ol class="numbered-list numbered-list_green">
     <li>
-      The
-      <a href="https://share.hsforms.com/1LsDFiHI-TJieFrBEgZyD4g3aanu"
-        >Cal-ITP onboarding form<span aria-label="(external link)">↗</span></a
-      >, which will take about 10 minutes to fill out, will make onboarding faster for your organization as we process details,
-      including which discount groups are applicable and how to represent your service on Cal-ITP Benefits.
+      <h3>Fill out the onboarding form</h3>
+      <ul>
+        <li>
+          The
+          <a href="https://share.hsforms.com/1LsDFiHI-TJieFrBEgZyD4g3aanu"
+            >Cal-ITP onboarding form<span aria-label="(external link)">↗</span></a
+          >, which will take about 10 minutes to fill out, will make onboarding faster for your organization as we process
+          details, including which discount groups are applicable and how to represent your service on Cal-ITP Benefits.
+        </li>
+        <li>Your Cal-ITP Account Manager can assist you with completing this form.</li>
+      </ul>
     </li>
-    <li>Your Cal-ITP Account Manager can assist you with completing this form.</li>
-  </ul>
-
-  <h3 class="numbered numbered_green" data-number="2">Set up discount groups and products</h3>
-  <p>
-    The specific pathways offered to riders of a transit agency are dependent on the discount programs the respective agency
-    offers. The following represents all pathways that an agency could elect to offer:
-  </p>
-  <ul>
-    <li><b>Older adults:</b> Riders 65 and older</li>
-    <li><b>Veterans:</b> Riders who served in the military, naval, or air service</li>
-    <li><b>Medicare cardholders:</b> Riders of any age who have Medicare coverage</li>
     <li>
-      <b>Individuals with low income:</b> Riders who receive
-      <a href="https://www.getcalfresh.org/en/">CalFresh<span aria-label="(external link)">↗</span></a> benefits
+      <h3>Set up discount groups and products</h3>
+      <p>
+        The specific pathways offered to riders of a transit agency are dependent on the discount programs the respective agency
+        offers. The following represents all pathways that an agency could elect to offer:
+      </p>
+      <ul>
+        <li><b>Older adults:</b> Riders 65 and older</li>
+        <li><b>Veterans:</b> Riders who served in the military, naval, or air service</li>
+        <li><b>Medicare cardholders:</b> Riders of any age who have Medicare coverage</li>
+        <li>
+          <b>Individuals with low income:</b> Riders who receive
+          <a href="https://www.getcalfresh.org/en/">CalFresh<span aria-label="(external link)">↗</span></a> benefits
+        </li>
+      </ul>
+      <p>
+        Want to learn more about supported enrollment pathways? Check out the
+        <a href="https://docs.calitp.org/benefits/#supported-enrollment-pathways"
+          >Cal-ITP Benefits documentation site<span aria-label="(external link)">↗</span></a
+        >.
+      </p>
     </li>
-  </ul>
-  <p>
-    Want to learn more about supported enrollment pathways? Check out the
-    <a href="https://docs.calitp.org/benefits/#supported-enrollment-pathways"
-      >Cal-ITP Benefits documentation site<span aria-label="(external link)">↗</span></a
-    >.
-  </p>
-
-  <h3 class="numbered numbered_green" data-number="3">Test the system</h3>
-  <p>
-    Coordinate with your Cal-ITP Account Manager to ensure that all technical processes are fully ready to go and you can go to
-    market with a seamless experience for eligible riders.
-  </p>
-
-  <h3 class="numbered numbered_green" data-number="4">Set a go-live date</h3>
-  <ul>
-    <li>Provide advance notice to help make the transition seamless.</li>
-    <li>Once your account is activated, you’ll be informed so you can move on to marketing enrollment to your riders.</li>
-  </ul>
-
-  <h3 class="numbered numbered_green" data-number="5">Market Cal-ITP Benefits to your riders</h3>
-  <p>
-    Cal-ITP Benefits allows eligible riders to enroll when it is convenient for them, enabling faster boarding and less operator
-    involvement. This improves the rider’s transit experience as a whole.
-  </p>
-  <h4 class="mt-3 h5">Let riders know contactless payments and Cal-ITP Benefits are an option for them</h4>
-  <ul>
     <li>
-      Focus marketing on contactless payments vs. other fare products and leverage existing resources, including our
-      <a href="/resources/marketing-materials/">bilingual explanation guides</a>.
+      <h3>Test the system</h3>
+      <p>
+        Coordinate with your Cal-ITP Account Manager to ensure that all technical processes are fully ready to go and you can go
+        to market with a seamless experience for eligible riders.
+      </p>
     </li>
-  </ul>
-
-  <h4 class="mt-3 h5">Highlight flexibility and ease of use</h4>
-  <ul>
-    <li>No need to purchase separate fare cards, which add cost.</li>
-    <li>Riders can use the same contactless payment methods they use for other purchases, saving time.</li>
-  </ul>
-
-  <h4 class="mt-3 h5">Make it simpler for all riders to adopt these new behaviors</h4>
-  <ul>
     <li>
-      Refer unbanked/underbanked transit riders to
-      <a href="https://joinbankon.org/">safe, inclusive banking accounts<span aria-label="(external link)">↗</span></a
-      >.
+      <h3>Set a go-live date</h3>
+      <ul>
+        <li>Provide advance notice to help make the transition seamless.</li>
+        <li>Once your account is activated, you’ll be informed so you can move on to marketing enrollment to your riders.</li>
+      </ul>
     </li>
-    <li>Offer digital or prepaid card options, which are often cheaper per ride compared to cash payments.</li>
     <li>
-      Cal-ITP Benefits will work with any of the four major credit or debit card schemes that an agency accepts (Visa, Mastercard,
-      Discover, American Express). All cards must be contactless-enabled, and, at this time, only physical cards—not smart
-      devices—will enable transit discounts.
-    </li>
-  </ul>
+      <h3>Market Cal-ITP Benefits to your riders</h3>
+      <p>
+        Cal-ITP Benefits allows eligible riders to enroll when it is convenient for them, enabling faster boarding and less
+        operator involvement. This improves the rider’s transit experience as a whole.
+      </p>
+      <h4 class="mt-3 h5">Let riders know contactless payments and Cal-ITP Benefits are an option for them</h4>
+      <ul>
+        <li>
+          Focus marketing on contactless payments vs. other fare products and leverage existing resources, including our
+          <a href="/resources/marketing-materials/">bilingual explanation guides</a>.
+        </li>
+      </ul>
 
-  <h4 class="mt-3 h5">Catalyze change in rider behavior at scale</h4>
-  <ul>
-    <li>
-      Increase tap to pay usage and Cal-ITP Benefits enrollments across the board by leveraging community partners, helping to
-      amplify the message of convenience and accessibility.
+      <h4 class="mt-3 h5">Highlight flexibility and ease of use</h4>
+      <ul>
+        <li>No need to purchase separate fare cards, which add cost.</li>
+        <li>Riders can use the same contactless payment methods they use for other purchases, saving time.</li>
+      </ul>
+
+      <h4 class="mt-3 h5">Make it simpler for all riders to adopt these new behaviors</h4>
+      <ul>
+        <li>
+          Refer unbanked/underbanked transit riders to
+          <a href="https://joinbankon.org/">safe, inclusive banking accounts<span aria-label="(external link)">↗</span></a
+          >.
+        </li>
+        <li>Offer digital or prepaid card options, which are often cheaper per ride compared to cash payments.</li>
+        <li>
+          Cal-ITP Benefits will work with any of the four major credit or debit card schemes that an agency accepts (Visa,
+          Mastercard, Discover, American Express). All cards must be contactless-enabled, and, at this time, only physical
+          cards—not smart devices—will enable transit discounts.
+        </li>
+      </ul>
+
+      <h4 class="mt-3 h5">Catalyze change in rider behavior at scale</h4>
+      <ul>
+        <li>
+          Increase tap to pay usage and Cal-ITP Benefits enrollments across the board by leveraging community partners, helping to
+          amplify the message of convenience and accessibility.
+        </li>
+      </ul>
     </li>
-  </ul>
+  </ol>
 
   <h2 class="pt-5 mt-2 mt-md-3">Additional info</h2>
   <h3 class="mt-0">Commonly asked questions</h3>

--- a/src/route-scheduling.liquid
+++ b/src/route-scheduling.liquid
@@ -58,94 +58,105 @@ description: Learn how transit providers can get service planning and scheduling
 
 <div class="container">
   <h2>Schedule and planning guide</h2>
-  <h3 class="numbered numbered_cyan-dark" data-number="1">Evaluate tools</h3>
-  <p>
-    Onboarding a new planning and scheduling tool is the perfect time to review your transit data quality. Check out
-    <a href="https://dot.ca.gov/cal-itp/california-transit-data-guidelines"
-      >California’s transit data guidelines<span aria-label="(external link)">↗</span></a
-    >
-    for more.
-  </p>
-  <p>Agencies that obtain Remix through the SLP, or receive free program access, will have options to get licenses for:</p>
-  <ul>
-    <li><b>Remix Planning:</b> Plan, design, and evaluate routes, detours, and full network redesigns.</li>
+  <h2>Schedule and planning guide</h2>
+  <ol class="numbered-list numbered-list_cyan-dark">
     <li>
-      <b>Remix Scheduling:</b> Streamline blocking, runcutting, and rostering. Create GTFS Schedule and adjust service in response
-      to real-world needs.
+      <h3>Evaluate tools</h3>
+      <p>
+        Onboarding a new planning and scheduling tool is the perfect time to review your transit data quality. Check out
+        <a href="https://dot.ca.gov/cal-itp/california-transit-data-guidelines"
+          >California’s transit data guidelines<span aria-label="(external link)">↗</span></a
+        >
+        for more.
+      </p>
+      <p>Agencies that obtain Remix through the SLP, or receive free program access, will have options to get licenses for:</p>
+      <ul>
+        <li><b>Remix Planning:</b> Plan, design, and evaluate routes, detours, and full network redesigns.</li>
+        <li>
+          <b>Remix Scheduling:</b> Streamline blocking, runcutting, and rostering. Create GTFS Schedule and adjust service in
+          response to real-world needs.
+        </li>
+        <li>
+          <b>Remix GTFS Publisher:</b> Maintain a single, compliant source of truth for scheduling data and trip-planning feeds.
+        </li>
+        <li>
+          <b>Remix Explore</b> (included with Planning and Scheduling modules): Visualize and analyze geospatial data to inform
+          better planning decisions.
+        </li>
+        <li>
+          <b>Free program period:</b> all program accepted agencies get organization-wide access through December 30, 2027, no
+          limits on seats or users.
+        </li>
+      </ul>
+      <p>
+        Note: The Streets module is not included in this program. For more details on Remix and their modules, visit their
+        <a href="https://ridewithvia.com/solutions/remix">website<span aria-label="(external link)">↗</span></a
+        >.
+      </p>
     </li>
     <li>
-      <b>Remix GTFS Publisher:</b> Maintain a single, compliant source of truth for scheduling data and trip-planning feeds.
+      <h3>Access options</h3>
+      <h4 class="mt-3">Software Licensing Program</h4>
+      <p>
+        Any agency in California can
+        <a
+          href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=SLP-23-70-0280G&SETID=STATE&VERSION_NBR=3"
+          >purchase Remix at competitive rates<span aria-label="(external link)">↗</span></a
+        >. Agencies are charged based on VOMS and given unlimited seats to onboard members of their team.
+      </p>
+      <p>You can purchase any combination of Remix modules (Planning, Scheduling, GTFS Publisher).</p>
+      <h4 class="mt-3">Cal-ITP’s Remix Program</h4>
+      <h5>Eligibility</h5>
+      <p>
+        Priority will be given to agencies who have only received 5311 funding in the past 3 years. Agencies who have received
+        5311 and 5307 funding are encouraged to apply. We’ll extend access to as soon as capacity allows.
+      </p>
+      <h5>How to apply</h5>
+      <p>
+        Fill out an
+        <a href="https://share.hsforms.com/13WkzY7taSoSdxBATWsNedQ3aanu"
+          >interest form<span aria-label="(external link)">↗</span></a
+        >
+        to apply. You’ll provide details about your current vendors, scheduling process, and GTFS pipeline. Within 30 days of
+        submitting the interest form, agencies will be notified of whether or not they are eligible. Approved agencies get
+        hands-on training, ongoing support, and dedicated technical assistance from Cal-ITP Account Managers and Remix. Maintain
+        and publish schedule data with Remix.
+      </p>
+      <h5>Program requirements</h5>
+      <p>Participating agencies must:</p>
+      <ul>
+        <li>Share existing tech stack and relevant tech vendor contracts</li>
+        <li>Work with Caltrans Data Quality Team to resolve any GTFS feed issues</li>
+        <li>Attend regular Cal-ITP check-ins and Remix trainings with their Cal-ITP Account Manager</li>
+        <li>Participate in regional coordination of the Remix implementation</li>
+        <li>
+          Use Remix as the primary tool to maintain and publish schedule data including the GTFS Schedule submitted to trip
+          planners and any CAD/AVL systems
+        </li>
+      </ul>
+      <p>Partner agencies receive:</p>
+      <ul>
+        <li>Personalized onboarding and staff training</li>
+        <li>Ongoing access to technical support and troubleshooting</li>
+        <li>GTFS health assessment and step-by-step improvements</li>
+        <li>Migration support</li>
+      </ul>
     </li>
     <li>
-      <b>Remix Explore</b> (included with Planning and Scheduling modules): Visualize and analyze geospatial data to inform better
-      planning decisions.
+      <h3>Schedule & plan</h3>
+      <p>
+        After purchasing the software you will receive logins from Remix. Remix offers some on-demand training,
+        <a href="https://ridewithvia.com/demo">reach out<span aria-label="(external link)">↗</span></a> to learn more. If you have
+        received free program licenses, training and onboarding is included.
+      </p>
+      <p>To ensure a successful launch:</p>
+      <ul>
+        <li>Review GTFS data in Remix and make sure its accurate before publishing to Remix URL.</li>
+        <li>Integrate your Remix GTFS URL with all relevant locations, i.e. TransitApp, Google Transit, Apple Maps</li>
+        <li>Incorporate the modules into your operations and reporting.</li>
+      </ul>
     </li>
-    <li>
-      <b>Free program period:</b> all program accepted agencies get organization-wide access through December 30, 2027, no limits
-      on seats or users.
-    </li>
-  </ul>
-  <p>
-    Note: The Streets module is not included in this program. For more details on Remix and their modules, visit their
-    <a href="https://ridewithvia.com/solutions/remix">website<span aria-label="(external link)">↗</span></a
-    >.
-  </p>
-  <h3 class="numbered numbered_cyan-dark" data-number="2">Access options</h3>
-  <h4 class="mt-3">Software Licensing Program</h4>
-  <p>
-    Any agency in California can
-    <a
-      href="https://caleprocure.ca.gov/pages/LPASearch/lpa-details.aspx?Page=ZZ_CTR_SUP_PG&Action=U&ForceSearch=Y&CNTRCT_ID=SLP-23-70-0280G&SETID=STATE&VERSION_NBR=3"
-      >purchase Remix at competitive rates<span aria-label="(external link)">↗</span></a
-    >. Agencies are charged based on VOMS and given unlimited seats to onboard members of their team.
-  </p>
-  <p>You can purchase any combination of Remix modules (Planning, Scheduling, GTFS Publisher).</p>
-  <h4 class="mt-3">Cal-ITP’s Remix Program</h4>
-  <h5>Eligibility</h5>
-  <p>
-    Priority will be given to agencies who have only received 5311 funding in the past 3 years. Agencies who have received 5311
-    and 5307 funding are encouraged to apply. We’ll extend access to as soon as capacity allows.
-  </p>
-  <h5>How to apply</h5>
-  <p>
-    Fill out an
-    <a href="https://share.hsforms.com/13WkzY7taSoSdxBATWsNedQ3aanu">interest form<span aria-label="(external link)">↗</span></a>
-    to apply. You’ll provide details about your current vendors, scheduling process, and GTFS pipeline. Within 30 days of
-    submitting the interest form, agencies will be notified of whether or not they are eligible. Approved agencies get hands-on
-    training, ongoing support, and dedicated technical assistance from Cal-ITP Account Managers and Remix. Maintain and publish
-    schedule data with Remix.
-  </p>
-  <h5>Program requirements</h5>
-  <p>Participating agencies must:</p>
-  <ul>
-    <li>Share existing tech stack and relevant tech vendor contracts</li>
-    <li>Work with Caltrans Data Quality Team to resolve any GTFS feed issues</li>
-    <li>Attend regular Cal-ITP check-ins and Remix trainings with their Cal-ITP Account Manager</li>
-    <li>Participate in regional coordination of the Remix implementation</li>
-    <li>
-      Use Remix as the primary tool to maintain and publish schedule data including the GTFS Schedule submitted to trip planners
-      and any CAD/AVL systems
-    </li>
-  </ul>
-  <p>Partner agencies receive:</p>
-  <ul>
-    <li>Personalized onboarding and staff training</li>
-    <li>Ongoing access to technical support and troubleshooting</li>
-    <li>GTFS health assessment and step-by-step improvements</li>
-    <li>Migration support</li>
-  </ul>
-  <h3 class="numbered numbered_cyan-dark" data-number="3">Schedule & plan</h3>
-  <p>
-    After purchasing the software you will receive logins from Remix. Remix offers some on-demand training,
-    <a href="https://ridewithvia.com/demo">reach out<span aria-label="(external link)">↗</span></a> to learn more. If you have
-    received free program licenses, training and onboarding is included.
-  </p>
-  <p>To ensure a successful launch:</p>
-  <ul>
-    <li>Review GTFS data in Remix and make sure its accurate before publishing to Remix URL.</li>
-    <li>Integrate your Remix GTFS URL with all relevant locations, i.e. TransitApp, Google Transit, Apple Maps</li>
-    <li>Incorporate the modules into your operations and reporting.</li>
-  </ul>
+  </ol>
   <h2 class="pt-5 mt-2 mt-md-3">Additional info</h2>
   <h3 class="mt-0">Commonly asked questions</h3>
   <h4 class="mt-0">If my agency already has Remix, can we still apply?</h4>

--- a/src/styles/guide.css
+++ b/src/styles/guide.css
@@ -26,8 +26,23 @@ ul > li:last-child {
   }
 }
 
-/* STEP LIST */
+/* STEP LIST and NUMBERED LIST */
 
+.numbered-list,
+.step-list {
+  counter-reset: li;
+  list-style: none;
+  padding-inline-start: unset;
+}
+/* override bootstrap defaults for nested lists */
+.numbered-list ul {
+  list-style-type: disc;
+  margin-bottom: 1rem;
+}
+.numbered-list h3 {
+  padding-bottom: var(--spacing-1);
+  padding-left: var(--spacing-10);
+}
 .step-list {
   /* This dance of padding/border/margin is needed to
      align the left border with the center of the markers
@@ -39,28 +54,29 @@ ul > li:last-child {
   /* Bottom padding ensures the vertical line extends below the last item. */
   padding-bottom: var(--spacing-3);
   font-size: var(--text-l);
-  list-style: none;
-  counter-reset: step-list;
 }
-.numbered {
+.numbered-list > li,
+.step-list li {
   position: relative;
-  padding-top: 0.25em;
-  padding-bottom: 0.25em;
-  padding-left: 2.5em;
-  margin-top: var(--spacing-5);
+}
+.numbered-list > li {
+  margin-bottom: 1em;
+  margin-top: calc(var(--spacing-5) + 8px);
 }
 .step-list li {
   margin-bottom: var(--spacing-3);
-  position: relative;
-  counter-increment: step-list;
 }
 .step-list li:last-child {
   margin-bottom: 0;
 }
-.step-list li::before,
-.numbered::before {
+.step-list li::before {
   display: block;
+}
+.numbered-list > li::before,
+.step-list li::before {
   border-radius: 100%;
+  content: counter(li);
+  counter-increment: li;
   position: absolute;
   background-color: var(--dsdl-gray-20);
   color: var(--dsdl-black);
@@ -70,58 +86,55 @@ ul > li:last-child {
   text-align: center;
 }
 .step-list li::before {
-  content: counter(step-list);
   width: var(--spacing-4);
   height: var(--spacing-4);
   left: calc(-1 * var(--spacing-6));
   line-height: calc(2rem + (1rem / 16));
 }
-.numbered::before {
-  content: attr(data-number);
-  width: 1.75em;
+.numbered-list > li::before {
+  font-size: 2em;
   height: 1.75em;
   left: 0;
-  top: 0;
-  font-size: 1em;
   line-height: 1.75em;
+  top: -8px;
+  width: 1.75em;
 }
-
 .step-list_yellow {
   border-left-color: var(--calitp-brand-yellow);
 }
-.step-list_yellow li::before,
-.numbered_yellow::before {
+.numbered-list_yellow > li::before,
+.step-list_yellow li::before {
   background-color: var(--calitp-brand-yellow);
   color: var(--dsdl-black);
 }
 .step-list_purple {
   border-left-color: var(--dsdl-purple-80);
 }
-.step-list_purple li::before,
-.numbered_purple::before {
+.numbered-list_purple > li::before,
+.step-list_purple li::before {
   background-color: var(--dsdl-purple-80);
   color: white;
 }
 .step-list_green {
   border-left-color: var(--dsdl-green-70);
 }
-.step-list_green li::before,
-.numbered_green::before {
+.numbered-list_green > li::before,
+.step-list_green li::before {
   background-color: var(--dsdl-green-70);
   color: white;
 }
 .step-list_cyan-light {
   border-left-color: var(--dsdl-cyan-10);
 }
-.step-list_cyan-light li::before,
-.numbered_cyan-light::before {
+.numbered-list_cyan-light > li::before,
+.step-list_cyan-light li::before {
   background-color: var(--dsdl-cyan-10);
 }
 .step-list_cyan-dark {
   border-left-color: var(--dsdl-cyan-60);
 }
-.step-list_cyan-dark li::before,
-.numbered_cyan-dark::before {
+.numbered-list_cyan-dark > li::before,
+.step-list_cyan-dark li::before {
   background-color: var(--dsdl-cyan-60);
   color: white;
 }

--- a/src/styles/guide.css
+++ b/src/styles/guide.css
@@ -26,22 +26,23 @@ ul > li:last-child {
   }
 }
 
-/* STEP LIST and NUMBERED LIST */
+/* STEP LIST and NUMBERED LIST (better naming would be welcomed :) ) */
 
 .numbered-list,
 .step-list {
   counter-reset: li;
   list-style: none;
-  padding-inline-start: unset;
+  padding-left: 0;
 }
 /* override bootstrap defaults for nested lists */
-.numbered-list ul {
+.numbered-list > ul {
   list-style-type: disc;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-2);
 }
 .numbered-list h3 {
-  padding-bottom: var(--spacing-1);
-  padding-left: var(--spacing-10);
+  padding-bottom: 0.25em;
+  padding-left: 2.5em;
+  padding-top: 0.25em;
 }
 .step-list {
   /* This dance of padding/border/margin is needed to
@@ -55,13 +56,13 @@ ul > li:last-child {
   padding-bottom: var(--spacing-3);
   font-size: var(--text-l);
 }
+/* we target only the direct child in numbered-list because the component allows for additional nested content */
 .numbered-list > li,
 .step-list li {
   position: relative;
 }
 .numbered-list > li {
-  margin-bottom: 1em;
-  margin-top: calc(var(--spacing-5) + 8px);
+  margin-top: var(--spacing-5);
 }
 .step-list li {
   margin-bottom: var(--spacing-3);
@@ -92,12 +93,17 @@ ul > li:last-child {
   line-height: calc(2rem + (1rem / 16));
 }
 .numbered-list > li::before {
-  font-size: 2em;
+  font-size: var(--text-xl);
   height: 1.75em;
   left: 0;
   line-height: 1.75em;
-  top: -8px;
+  top: 0;
   width: 1.75em;
+}
+@media (min-width: 992px) {
+  .numbered-list > li::before {
+    font-size: var(--text-xxl);
+  }
 }
 .step-list_yellow {
   border-left-color: var(--calitp-brand-yellow);

--- a/src/styles/guide.css
+++ b/src/styles/guide.css
@@ -35,9 +35,12 @@ ul > li:last-child {
   padding-left: 0;
 }
 /* override bootstrap defaults for nested lists */
-.numbered-list > ul {
-  list-style-type: disc;
+.numbered-list > li > ol,
+.numbered-list > li > ul {
   margin-bottom: var(--spacing-2);
+}
+.numbered-list > li > ul {
+  list-style-type: disc;
 }
 .numbered-list h3 {
   padding-bottom: 0.25em;

--- a/src/tap-to-pay.liquid
+++ b/src/tap-to-pay.liquid
@@ -62,358 +62,372 @@ with contactless hardware and fare-calculation and payment-processing software.'
 
 <div class="container">
   <h2>Go contactless with tap to pay</h2>
-  <h3 class="numbered numbered_yellow" data-number="1">Prepare</h3>
-  <p><a href="/data-plans">Data connection</a> is required to enable tap to pay fare collection.</p>
-  <ul>
+  <h2>Go contactless with tap to pay</h2>
+  <ol class="numbered-list numbered-list_yellow">
     <li>
-      Check out the pre-negotiated <a href="/data-plans#contracts">data plans</a>, as your agency may be eligible to upgrade and
-      save on monthly costs.
+      <h3>Prepare</h3>
+      <p><a href="/data-plans">Data connection</a> is required to enable tap to pay fare collection.</p>
+      <ul>
+        <li>
+          Check out the pre-negotiated <a href="/data-plans#contracts">data plans</a>, as your agency may be eligible to upgrade
+          and save on monthly costs.
+        </li>
+      </ul>
+      <p>
+        Verify your GTFS Realtime feeds are valid and up-to-date. GTFS Realtime is required if you have distance or zoned-based
+        fares, and is recommended for all fare types.
+      </p>
+      <ul>
+        <li>
+          Explore pre-negotiated <a href="/gtfs-realtime#contracts">GTFS Realtime MSAs</a> or
+          <a href="mailto:hello@calitp.org" aria-label="send email to hello at cal i t p dot org">connect</a> with a Cal-ITP
+          Account Manager for support.
+        </li>
+      </ul>
+      <p>Review your fare policy and identify opportunities to simplify.</p>
+      <ul>
+        <li>
+          Check out Cal-ITP's <a href="/resources/statewide-fare-guidelines-toolkit">Statewide Fare Guidelines Toolkit</a> for
+          more.
+        </li>
+      </ul>
+      <p>Prepare your stakeholders.</p>
+      <ul>
+        <li>
+          If you need an informational presentation to share with your staff, leadership, or board of directors, please review the
+          <a href="/resources/contactless-payments-introduction">Contactless Payments Introduction</a>.
+        </li>
+      </ul>
+      <h4 class="mt-3">Assess funding options</h4>
+      <p>
+        Projects resulting from these MSAs may be funded through grants from the
+        <a href="https://www.transit.dot.gov/funding/grants/grant-programs">FTA<span aria-label="(external link)">↗</span></a
+        >, <a href="https://dot.ca.gov/">Caltrans<span aria-label="(external link)">↗</span></a
+        >, and other sources of local and state public funding. Check with your funding agencies.
+      </p>
+      <h5>Estimated cost ranges</h5>
+      <p>Costs are influenced by many factors, including:</p>
+      <ul>
+        <li>Fleet size</li>
+        <li>Number of payment acceptance devices (PADs) per vehicle (plus spares!)</li>
+        <li>Monthly fare revenue</li>
+        <li>Total transactions processed using open loop</li>
+      </ul>
+      <p>
+        The <a href="/resources/msa-cost-estimation-tool">MSA Cost Estimation Tool</a> will help you create cost estimates for
+        purchasing contactless payment hardware and software services. This workbook helps transit agency staff to:
+      </p>
+      <ul>
+        <li>Compare MSA-awarded vendors’ maximum prices</li>
+        <li>Develop ballpark estimates for budgeting purposes and board presentations</li>
+        <li>Make scoping decisions as you prepare to email vendors</li>
+      </ul>
+      <p>
+        The prices in this workbook are maximums, and transit agencies are strongly encouraged to reach out to vendors directly
+        for tailored pricing. Prices may be reduced and/or fee categories waived at vendors’ sole discretion.
+      </p>
     </li>
-  </ul>
-  <p>
-    Verify your GTFS Realtime feeds are valid and up-to-date. GTFS Realtime is required if you have distance or zoned-based fares,
-    and is recommended for all fare types.
-  </p>
-  <ul>
     <li>
-      Explore pre-negotiated <a href="/gtfs-realtime#contracts">GTFS Realtime MSAs</a> or
-      <a href="mailto:hello@calitp.org" aria-label="send email to hello at cal i t p dot org">connect</a> with a Cal-ITP Account
-      Manager for support.
-    </li>
-  </ul>
-  <p>Review your fare policy and identify opportunities to simplify.</p>
-  <ul>
-    <li>
-      Check out Cal-ITP's <a href="/resources/statewide-fare-guidelines-toolkit">Statewide Fare Guidelines Toolkit</a> for more.
-    </li>
-  </ul>
-  <p>Prepare your stakeholders.</p>
-  <ul>
-    <li>
-      If you need an informational presentation to share with your staff, leadership, or board of directors, please review the
-      <a href="/resources/contactless-payments-introduction">Contactless Payments Introduction</a>.
-    </li>
-  </ul>
-  <h4 class="mt-3">Assess funding options</h4>
-  <p>
-    Projects resulting from these MSAs may be funded through grants from the
-    <a href="https://www.transit.dot.gov/funding/grants/grant-programs">FTA<span aria-label="(external link)">↗</span></a
-    >, <a href="https://dot.ca.gov/">Caltrans<span aria-label="(external link)">↗</span></a
-    >, and other sources of local and state public funding. Check with your funding agencies.
-  </p>
-  <h5>Estimated cost ranges</h5>
-  <p>Costs are influenced by many factors, including:</p>
-  <ul>
-    <li>Fleet size</li>
-    <li>Number of payment acceptance devices (PADs) per vehicle (plus spares!)</li>
-    <li>Monthly fare revenue</li>
-    <li>Total transactions processed using open loop</li>
-  </ul>
-  <p>
-    The <a href="/resources/msa-cost-estimation-tool">MSA Cost Estimation Tool</a> will help you create cost estimates for
-    purchasing contactless payment hardware and software services. This workbook helps transit agency staff to:
-  </p>
-  <ul>
-    <li>Compare MSA-awarded vendors’ maximum prices</li>
-    <li>Develop ballpark estimates for budgeting purposes and board presentations</li>
-    <li>Make scoping decisions as you prepare to email vendors</li>
-  </ul>
-  <p>
-    The prices in this workbook are maximums, and transit agencies are strongly encouraged to reach out to vendors directly for
-    tailored pricing. Prices may be reduced and/or fee categories waived at vendors’ sole discretion.
-  </p>
-  <h3 class="numbered numbered_yellow" data-number="2">Assess vendors and review MSAs</h3>
-  <p>
-    Agencies can purchase from the MSAs for Payment Acceptance Devices (Category A) and Transit Processor Services (Category B),
-    as well as the Electronic Payment Acceptance Services (EPAY) MSAs, to begin accepting contactless open loop payments.
-  </p>
-  <p>Click on each MSA for terms and conditions.</p>
-  <h4 class="mt-3">PADs (Payment Acceptance Devices) MSAs</h4>
-  <p>
-    Onboard, on-platform, and mobile fare inspection devices that are equipped to read riders’ contactless bank cards and smart
-    devices.
-  </p>
-  <div class="table-responsive my-3">
-    <table class="table_yellow mb-2">
-      <thead>
-        <tr>
-          <th scope="col">Vendors</th>
-          <th scope="col">MSAs</th>
-          <th scope="col">Transit Processor integrations</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th>INIT</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
-              >5-21-70-28-01</a
-            >
-          </td>
-          <td>
-            <ul>
-              <li>INIT</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th>Kuba</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-02"
-              >5-21-70-28-02</a
-            >
-          </td>
-          <td>
-            <ul>
-              <li>Enghouse</li>
-              <li>Littlepay</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th>SC Soft</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-03"
-              >5-21-70-28-03</a
-            >
-          </td>
-          <td>
-            <ul>
-              <li>Enghouse</li>
-              <li>Littlepay</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+      <h3>Assess vendors and review MSAs</h3>
+      <p>
+        Agencies can purchase from the MSAs for Payment Acceptance Devices (Category A) and Transit Processor Services (Category
+        B), as well as the Electronic Payment Acceptance Services (EPAY) MSAs, to begin accepting contactless open loop payments.
+      </p>
+      <p>Click on each MSA for terms and conditions.</p>
+      <h4 class="mt-3">PADs (Payment Acceptance Devices) MSAs</h4>
+      <p>
+        Onboard, on-platform, and mobile fare inspection devices that are equipped to read riders’ contactless bank cards and
+        smart devices.
+      </p>
+      <div class="table-responsive my-3">
+        <table class="table_yellow mb-2">
+          <thead>
+            <tr>
+              <th scope="col">Vendors</th>
+              <th scope="col">MSAs</th>
+              <th scope="col">Transit Processor integrations</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>INIT</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
+                  >5-21-70-28-01</a
+                >
+              </td>
+              <td>
+                <ul>
+                  <li>INIT</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>Kuba</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-02"
+                  >5-21-70-28-02</a
+                >
+              </td>
+              <td>
+                <ul>
+                  <li>Enghouse</li>
+                  <li>Littlepay</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>SC Soft</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-03"
+                  >5-21-70-28-03</a
+                >
+              </td>
+              <td>
+                <ul>
+                  <li>Enghouse</li>
+                  <li>Littlepay</li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
-  <h4 class="mt-3">Transit Processor MSAs</h4>
-  <p>
-    Software that instantly determines the correct fare for a trip based on distance, applicable discounts, and frequency of
-    travel.
-  </p>
-  <div class="table-responsive my-3">
-    <table class="table_yellow mb-2">
-      <thead>
-        <tr>
-          <th scope="col">Vendors</th>
-          <th scope="col">MSAs</th>
-          <th scope="col">Rider benefits & discounts</th>
-          <th scope="col">Fare calculation</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th>Bytemark</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-04"
-              >5-21-70-28-04</a
-            >
-          </td>
-          <td>Not integrated with Cal-ITP rider benefits</td>
-          <td>
-            <ul>
-              <li>Basic transfers</li>
-              <li>Fare capping</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th>Enghouse</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-05"
-              >5-21-70-28-05</a
-            >
-          </td>
-          <td>
-            <ul>
-              <li>Older adults</li>
-              <li>Veterans</li>
-              <li>Medicare recipients</li>
-              <li>CalFresh recipients</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>Basic transfers</li>
-              <li>Fare capping</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th>INIT</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
-              >5-21-70-28-01</a
-            >
-          </td>
-          <td>Not integrated with Cal-ITP rider benefits</td>
-          <td>
-            <ul>
-              <li>Basic transfers</li>
-              <li>Fare capping</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th>Littlepay</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-06"
-              >5-21-70-28-06</a
-            >
-          </td>
-          <td>
-            <ul>
-              <li>Older adults</li>
-              <li>Veterans</li>
-              <li>Medicare recipients</li>
-              <li>CalFresh recipients</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>Basic transfers</li>
-              <li>Fare capping</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+      <h4 class="mt-3">Transit Processor MSAs</h4>
+      <p>
+        Software that instantly determines the correct fare for a trip based on distance, applicable discounts, and frequency of
+        travel.
+      </p>
+      <div class="table-responsive my-3">
+        <table class="table_yellow mb-2">
+          <thead>
+            <tr>
+              <th scope="col">Vendors</th>
+              <th scope="col">MSAs</th>
+              <th scope="col">Rider benefits & discounts</th>
+              <th scope="col">Fare calculation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Bytemark</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-04"
+                  >5-21-70-28-04</a
+                >
+              </td>
+              <td>Not integrated with Cal-ITP rider benefits</td>
+              <td>
+                <ul>
+                  <li>Basic transfers</li>
+                  <li>Fare capping</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>Enghouse</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-05"
+                  >5-21-70-28-05</a
+                >
+              </td>
+              <td>
+                <ul>
+                  <li>Older adults</li>
+                  <li>Veterans</li>
+                  <li>Medicare recipients</li>
+                  <li>CalFresh recipients</li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li>Basic transfers</li>
+                  <li>Fare capping</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>INIT</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-01"
+                  >5-21-70-28-01</a
+                >
+              </td>
+              <td>Not integrated with Cal-ITP rider benefits</td>
+              <td>
+                <ul>
+                  <li>Basic transfers</li>
+                  <li>Fare capping</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>Littlepay</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-21-70-28-06"
+                  >5-21-70-28-06</a
+                >
+              </td>
+              <td>
+                <ul>
+                  <li>Older adults</li>
+                  <li>Veterans</li>
+                  <li>Medicare recipients</li>
+                  <li>CalFresh recipients</li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li>Basic transfers</li>
+                  <li>Fare capping</li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
-  <h5 class="mt-3 h4">Payment Processor MSAs</h5>
-  <p>
-    Software embedded in fare validators that transmits money from a rider’s bank card to the Transit Provider’s bank account.
-  </p>
-  <div class="table-responsive my-3">
-    <table class="table_yellow mb-2">
-      <thead>
-        <tr>
-          <th scope="col">Vendors</th>
-          <th scope="col">MSAs</th>
-          <th scope="col">Types of transactions</th>
-          <th scope="col">Payment networks</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th>Fiserv*</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-02"
-              >5-22-70-22-02</a
-            >
-          </td>
-          <td>
-            <ul>
-              <li>Credit</li>
-              <li>Debit</li>
-              <li>Mobile wallet</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>American Express</li>
-              <li>Discover</li>
-              <li>Mastercard</li>
-              <li>Visa</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th>Elavon*</th>
-          <td>
-            <a
-              href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-01"
-              >5-22-70-22-01</a
-            >
-          </td>
-          <td>
-            <ul>
-              <li>Credit</li>
-              <li>Debit</li>
-              <li>Mobile wallet</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>American Express</li>
-              <li>Discover</li>
-              <li>Mastercard</li>
-              <li>Visa</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <p class="table-caption">*Available to California agencies only.</p>
+      <h5 class="mt-3 h4">Payment Processor MSAs</h5>
+      <p>
+        Software embedded in fare validators that transmits money from a rider’s bank card to the Transit Provider’s bank account.
+      </p>
+      <div class="table-responsive my-3">
+        <table class="table_yellow mb-2">
+          <thead>
+            <tr>
+              <th scope="col">Vendors</th>
+              <th scope="col">MSAs</th>
+              <th scope="col">Types of transactions</th>
+              <th scope="col">Payment networks</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Fiserv*</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-02"
+                  >5-22-70-22-02</a
+                >
+              </td>
+              <td>
+                <ul>
+                  <li>Credit</li>
+                  <li>Debit</li>
+                  <li>Mobile wallet</li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li>American Express</li>
+                  <li>Discover</li>
+                  <li>Mastercard</li>
+                  <li>Visa</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>Elavon*</th>
+              <td>
+                <a
+                  href="https://caleprocure.ca.gov/PSRelay/ZZ_PO.ZZ_CTR_SUP_CMP.GBL?Page=ZZ_CTR_SUP_PG&Action=U&SETID=STATE&CNTRCT_ID=5-22-70-22-01"
+                  >5-22-70-22-01</a
+                >
+              </td>
+              <td>
+                <ul>
+                  <li>Credit</li>
+                  <li>Debit</li>
+                  <li>Mobile wallet</li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li>American Express</li>
+                  <li>Discover</li>
+                  <li>Mastercard</li>
+                  <li>Visa</li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="table-caption">*Available to California agencies only.</p>
 
-  <h4 class="mt-3">Draft a Scope of Work (SOW)</h4>
-  <p>
-    Draft a scope of work using Cal-ITP's <a href="/resources/sow-tap-to-pay">SOW Template</a>. Completing an SOW will assist your
-    agency with key decisions as you work toward purchasing hardware and software services. Be sure to specify your operating
-    goals, technical environment, and any must-have features or services. Your <a href="/contact">Cal-ITP Account Manager</a> can
-    offer guidance and review your SOW before sending it to vendors.
-  </p>
-  <h3 class="numbered numbered_yellow" data-number="3">Engage vendors</h3>
-  <h4 class="mt-3">Send SOW</h4>
-  <p>
-    We recommend sending the SOW to all MSA-awarded hardware and software services vendors. You can find their contact information
-    in the MSA User Instructions document (which is linked from each vendor’s contract number).
-  </p>
-  <p>
-    You can use <a href="/resources/email-template-tap-to-pay">this email template</a> to send out your SOW, cc:
-    <a href="mailto:hello@calitp.org">hello@calitp.org</a>. Unless otherwise specified by the transit agency, each vendor is
-    expected to respond within five business days of receiving the SOW.
-  </p>
-  <h3 class="numbered numbered_yellow" data-number="4">Select vendor to purchase from</h3>
-  <p>
-    Look over the proposals you receive from each vendor and decide which vendors you want to negotiate with. When you reach an
-    agreement, you’re ready to place your order by signing a User Agreement contract for your purchases. The User Agreement
-    contract can be this <a href="/resources/user-agreement-tap-to-pay">Sample User Agreement</a> or the Standard Agreement (<a
-      href="https://www.dgs.ca.gov/ols/Forms?search=213&topicCategoryFilters=&audienceCategoryFilters=9048d318e266493abfd2361dc40d1f45&sort=relevance&activeFilters=audience%7C&page=1"
-      >STD 213<span aria-label="(external link)">↗</span></a
-    >). The User Agreement will incorporate the terms of the MSA by reference, and will contain the scope of work (which describes
-    all finalized vendor expectations) and payment provisions.
-  </p>
-  <h3 class="numbered numbered_yellow" data-number="5">Implementation</h3>
-  <h4 class="mt-3">Get ready to launch</h4>
-  <p>Cal-ITP can work with you to develop an operational launch plan for your agency, covering key elements such as:</p>
-  <ul>
-    <li>Hardware installation</li>
-    <li>Fare calculation software configuration</li>
-    <li>Payment processor onboarding</li>
-    <li>End-to-end testing</li>
-    <li>Soft launch to full launch</li>
-    <li>Setting up finance dashboards</li>
-  </ul>
-  <p>
-    Additionally,
-    <a href="/resources/marketing-materials">marketing materials</a> are available, which can be used for website copy and rider
-    communications.
-  </p>
-  <h4 class="mt-3">Leverage a phased-approach</h4>
-  <p>
-    Consider approaching your roll out of tap to pay in phases. Riders will be able to benefit from this new, easier way to pay
-    immediately. Then, you can continue to add additional features like additional discount offerings, multi-agency fare products,
-    and payment options for the un/underbanked to grow your tap to pay system over time.
-  </p>
-  <h4 class="mt-3">Maintenance and support</h4>
-  <p>
-    Cal-ITP is here to help! Please download and review our
-    <a href="/resources/contactless-payments-support-framework">Support Framework</a> – a document you can fill in and use to
-    provide information to your internal team(s) about roles and responsibilities, common troubleshooting steps, how to manage
-    your vendor relationships, and how to monitor key performance outcomes.
-  </p>
+      <h4 class="mt-3">Draft a Scope of Work (SOW)</h4>
+      <p>
+        Draft a scope of work using Cal-ITP's <a href="/resources/sow-tap-to-pay">SOW Template</a>. Completing an SOW will assist
+        your agency with key decisions as you work toward purchasing hardware and software services. Be sure to specify your
+        operating goals, technical environment, and any must-have features or services. Your
+        <a href="/contact">Cal-ITP Account Manager</a> can offer guidance and review your SOW before sending it to vendors.
+      </p>
+    </li>
+    <li>
+      <h3>Engage vendors</h3>
+      <h4 class="mt-3">Send SOW</h4>
+      <p>
+        We recommend sending the SOW to all MSA-awarded hardware and software services vendors. You can find their contact
+        information in the MSA User Instructions document (which is linked from each vendor’s contract number).
+      </p>
+      <p>
+        You can use <a href="/resources/email-template-tap-to-pay">this email template</a> to send out your SOW, cc:
+        <a href="mailto:hello@calitp.org">hello@calitp.org</a>. Unless otherwise specified by the transit agency, each vendor is
+        expected to respond within five business days of receiving the SOW.
+      </p>
+    </li>
+    <li>
+      <h3>Select vendor to purchase from</h3>
+      <p>
+        Look over the proposals you receive from each vendor and decide which vendors you want to negotiate with. When you reach
+        an agreement, you’re ready to place your order by signing a User Agreement contract for your purchases. The User Agreement
+        contract can be this <a href="/resources/user-agreement-tap-to-pay">Sample User Agreement</a> or the Standard Agreement (<a
+          href="https://www.dgs.ca.gov/ols/Forms?search=213&topicCategoryFilters=&audienceCategoryFilters=9048d318e266493abfd2361dc40d1f45&sort=relevance&activeFilters=audience%7C&page=1"
+          >STD 213<span aria-label="(external link)">↗</span></a
+        >). The User Agreement will incorporate the terms of the MSA by reference, and will contain the scope of work (which
+        describes all finalized vendor expectations) and payment provisions.
+      </p>
+    </li>
+    <li>
+      <h3>Implementation</h3>
+      <h4 class="mt-3">Get ready to launch</h4>
+      <p>Cal-ITP can work with you to develop an operational launch plan for your agency, covering key elements such as:</p>
+      <ul>
+        <li>Hardware installation</li>
+        <li>Fare calculation software configuration</li>
+        <li>Payment processor onboarding</li>
+        <li>End-to-end testing</li>
+        <li>Soft launch to full launch</li>
+        <li>Setting up finance dashboards</li>
+      </ul>
+      <p>
+        Additionally,
+        <a href="/resources/marketing-materials">marketing materials</a> are available, which can be used for website copy and
+        rider communications.
+      </p>
+      <h4 class="mt-3">Leverage a phased-approach</h4>
+      <p>
+        Consider approaching your roll out of tap to pay in phases. Riders will be able to benefit from this new, easier way to
+        pay immediately. Then, you can continue to add additional features like additional discount offerings, multi-agency fare
+        products, and payment options for the un/underbanked to grow your tap to pay system over time.
+      </p>
+      <h4 class="mt-3">Maintenance and support</h4>
+      <p>
+        Cal-ITP is here to help! Please download and review our
+        <a href="/resources/contactless-payments-support-framework">Support Framework</a> – a document you can fill in and use to
+        provide information to your internal team(s) about roles and responsibilities, common troubleshooting steps, how to manage
+        your vendor relationships, and how to monitor key performance outcomes.
+      </p>
+    </li>
+  </ol>
   <h2 class="pt-5 mt-2 mt-md-3">Additional info</h2>
   <h3 class="mt-0">Commonly asked questions</h3>
 


### PR DESCRIPTION
closes #906

### The solution: [wrap all numbered headings in an `<ol>`](https://deploy-preview-934--cal-itp-mobility-marketplace.netlify.app/demo/#numbered-headings)

disclaimer: this takes (heavy) inspiration from the [Mass.gov's process list](https://www.mass.gov/how-to/apply-for-unemployment-insurance-benefits) that @cmajel shared.

```html
<ol class="numbered-list">
  <li>
    <h3>Take the first step</h3>
  </li>
  <li>
    <h3>keep walking</h3>
  </li>
</ol>  
```

updating the guides manually would have been a slog but copilot made quick work of it in 1e09648. 👼 
<img width="543" height="718" alt="Screenshot 2026-06-17 at 2 57 21 PM" src="https://github.com/user-attachments/assets/f0cffe11-58d4-4777-91f4-2b5dec957d9c" />

