### PR TITLE
fix: ensure header link :focus style doesn't survive browser history navigation on mobile devices

### DIFF
--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -6,10 +6,16 @@
   font-size: var(--text-l);
 }
 
-.btn.btn-outline-primary:focus,
-.btn.btn-outline-primary:hover {
+.btn.btn-outline-primary:focus {
   border-color: var(--button-hover-border-color);
   background-color: var(--button-hover-bg-color);
+}
+
+@media (any-hover: hover) {
+  .btn.btn-outline-primary:hover {
+    border-color: var(--button-hover-border-color);
+    background-color: var(--button-hover-bg-color);
+  }
 }
 
 .btn.btn-outline-primary:active {
@@ -31,9 +37,11 @@
   padding: var(--spacing-1) var(--spacing-2);
   text-decoration: none;
 }
-.dl-button:hover {
-  background-color: var(--button-hover-bg-color);
-  border-color: var(--button-hover-border-color);
+@media (any-hover: hover) {
+  .dl-button:hover {
+    background-color: var(--button-hover-bg-color);
+    border-color: var(--button-hover-border-color);
+  }
 }
 .dl-button:focus {
   outline: var(--button-focus-outline);

--- a/src/styles/doc-preview.css
+++ b/src/styles/doc-preview.css
@@ -27,10 +27,12 @@
   font-size: var(--button-large-font-size);
   font-weight: var(--button-large-font-weight);
 }
-.dl-hero .dl-button:hover {
-  border-color: var(--button-large-hover-border-color);
-  background-color: var(--button-large-hover-bg-color);
-  color: var(--button-large-hover-text-color);
+@media (any-hover: hover) {
+  .dl-hero .dl-button:hover {
+    border-color: var(--button-large-hover-border-color);
+    background-color: var(--button-large-hover-bg-color);
+    color: var(--button-large-hover-text-color);
+  }
 }
 .dl-hero-image > img {
   display: block;

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -41,11 +41,11 @@
   outline: 1px solid #fff;
   outline-offset: 2px;
 }
-
-.footer a:hover {
-  color: var(--calitp-brand-yellow);
+@media (any-hover: hover) {
+  .footer a:hover {
+    color: var(--calitp-brand-yellow);
+  }
 }
-
 .footer nav a,
 a:has(> img) {
   text-decoration: none;

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -42,10 +42,17 @@
   outline-offset: var(--button-focus-outline-offset);
 }
 
-.global-nav a:hover,
-.header a.contact:hover {
-  border-color: var(--button-hover-border-color);
-  background-color: var(--button-hover-bg-color);
+/*
+this media query ensures that the user device has access to at least one input method that supports hover
+but the real reason for it is to side-step the propensity of some browsers to blend/persist
+:hover and :focus during history navigation and reapply the :hover style when "Back" is clicked
+*/
+@media (any-hover: hover) {
+  .global-nav a:hover,
+  .header a.contact:hover {
+    border-color: var(--button-hover-border-color);
+    background-color: var(--button-hover-bg-color);
+  }
 }
 
 .global-nav a:active,

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -44,8 +44,8 @@
 
 /*
 this media query ensures that the user device has access to at least one input method that supports hover
-but the real reason for it is to side-step the propensity of some browsers to blend/persist
-:hover and :focus during history navigation and reapply the :hover style when "Back" is clicked
+the main reason for it is to ensure that mobile devices don't end up with a stuck :hover style on an element
+after the "Back" button is used for navigation
 */
 @media (any-hover: hover) {
   .global-nav a:hover,

--- a/src/styles/related-nav.css
+++ b/src/styles/related-nav.css
@@ -16,13 +16,9 @@
   text-decoration: none;
 }
 .related-nav-link:active,
-.related-nav-link:focus,
-.related-nav-link:hover {
-  color: var(--button-active-text-color);
-}
-.related-nav-link:focus,
-.related-nav-link:hover {
+.related-nav-link:focus {
   background-color: var(--dsdl-cyan-60);
+  color: var(--button-active-text-color);
 }
 .related-nav-link:focus {
   outline: var(--button-focus-outline);
@@ -31,6 +27,12 @@
 .related-nav-link:active {
   border-color: var(--button-active-border-color);
   background-color: var(--button-active-bg-color);
+}
+@media (any-hover: hover) {
+  .related-nav-link:hover {
+    background-color: var(--dsdl-cyan-60);
+    color: var(--button-active-text-color);
+  }
 }
 .related-nav-link > .text {
   flex-grow: 1;


### PR DESCRIPTION
this change is 2/3 of the way toward resolving #871. 

AFAICT the only thing that will clear/reset an applied `:hover` style on desktop after history navigation is subsequent page interaction. however, omitting `:hover` styles altogether on devices that don't actually support it ensures that the conflated style doesn't stubbornly persist even _after_ the user starts to interact with the page.

before:
<img width="650" height="788" alt="before" src="https://github.com/user-attachments/assets/ee1cbf32-3cd2-43ff-b84c-5511048b9eb8" />

after:
<img width="650" height="788" alt="after" src="https://github.com/user-attachments/assets/4f8eeefd-1e69-44de-9807-e5366de4c9c6" />

components that have been re-treated:

1. homepage guide card links
1. header links
1. footer links
1. related guide links
1. view/download links

<img width="204" height="307" alt="Screenshot 2026-06-23 at 9 33 06 AM" src="https://github.com/user-attachments/assets/531261c6-c7d3-483b-8c95-fb93f5d703bf" />
<img width="147" height="187" alt="Screenshot 2026-06-23 at 9 33 18 AM" src="https://github.com/user-attachments/assets/238d373b-418c-4899-9ddf-7e81214bd1c4" />
<img width="325" height="294" alt="Screenshot 2026-06-23 at 9 33 48 AM" src="https://github.com/user-attachments/assets/f1839f22-7aed-4a66-8533-24d98d912e25" />
<img width="313" height="445" alt="Screenshot 2026-06-23 at 9 34 23 AM" src="https://github.com/user-attachments/assets/47964a92-f104-44e3-ab97-2dcb0e3910ff" />

---

initially i just asked Gemini about this, but after i played around a bit with the fix it recommended i did a little more research of my own and found a really helpful article written by a human being: https://jacobpadilla.com/writing/hover-media-query

[`any-hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/any-hover) definitely was/is a new one for me.

~there are a few other locations in the CSS where we apply `:hover` styles, but I couldn't reproduce undesirable sticky behavior for any of them so I left all other declarations alone.~