### PR TITLE
chore: cache node install in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,22 +3,25 @@ FROM python:3.12
 ENV USER=mobimart
 ENV HOME=/home/$USER
 
+ENV WORK_DIR=$HOME/site \
+    MISE_DIR=$HOME/mise
+
 RUN useradd --create-home --shell /bin/bash $USER && \
+    mkdir $WORK_DIR && \
     chown -R $USER $HOME
 
-WORKDIR $HOME/site
+WORKDIR $WORK_DIR
 
 # Install mise (to manage Node.js) https://mise.jdx.dev/mise-cookbook/docker.html#docker-image-with-mise
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-ENV MISE_DATA_DIR="$HOME/mise"
-ENV MISE_CONFIG_DIR="$HOME/mise"
-ENV MISE_CACHE_DIR="$HOME/mise/cache"
+ENV MISE_DATA_DIR=$MISE_DIR
+ENV MISE_CONFIG_DIR=$MISE_DIR
+ENV MISE_CACHE_DIR="$MISE_DIR/cache"
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
-ENV PATH="$HOME/mise/shims:$PATH"
+ENV MISE_TRUSTED_CONFIG_PATHS=$WORK_DIR
+ENV PATH="$MISE_DIR/shims:$PATH"
 
 RUN curl https://mise.run | sh
-
-RUN apt-get update
 
 # Install Python dependencies
 COPY .devcontainer/requirements.txt .devcontainer/requirements.txt
@@ -28,3 +31,7 @@ RUN pip install --no-cache-dir -r .devcontainer/requirements.txt
 USER $USER
 
 RUN git config --global --add safe.directory $HOME
+
+# Install Node.js and npm dependencies
+COPY mise.toml .node-version package.json package-lock.json ./
+RUN mise exec -- npm install -g npm@latest && npm clean-install

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -6,3 +6,4 @@ services:
     command: sleep infinity
     volumes:
       - ..:/home/mobimart/site
+      - /home/mobimart/site/node_modules

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,6 @@
   "dockerComposeFile": "compose.yml",
   "service": "site",
   "workspaceFolder": "/home/mobimart/site",
-  "remoteEnv": {
-    "MISE_TRUSTED_CONFIG_PATHS": "${containerEnv:PATH}:/home/mobimart/site"
-  },
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   "customizations": {
     "vscode": {

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -6,8 +6,3 @@ pre-commit install --install-hooks --overwrite
 
 # manage commit-msg hooks
 pre-commit install --hook-type commit-msg
-
-# triggers a Node.js install (from .node-version file) and updates the npm cli
-mise exec -- npm install -g npm@latest
-# https://docs.npmjs.com/cli/commands/npm-ci
-mise exec -- npm clean-install


### PR DESCRIPTION
resolves #941 

i didn't notice it when i was working on https://github.com/cal-itp/calitp.org/pull/663, but one side-effect of mounting 'node_modules' as a volume is that we can't just nuke it from within the devcontainer in the event that we genuinely want to start from scratch.

<img width="317" height="271" alt="Screenshot 2026-06-24 at 3 55 58 PM" src="https://github.com/user-attachments/assets/df7dd5cd-6710-47ae-b9ba-fee71f58c3d1" />

i doubt it'll come up often in practice, but a quick chat with Gemini clued me into the fact that it is possible to use `find` to imitate the behavior of `rm -rf node_modules` and leave the parent directory intact.

```bash
find ./node_modules -mindepth 1 -delete
```