### PR TITLE
Revert: stop pointing at pinned DSDL netlify permalink

### DIFF
--- a/src/_layouts/main.liquid
+++ b/src/_layouts/main.liquid
@@ -18,8 +18,7 @@
       integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
       crossorigin="anonymous"
     >
-    <!-- 2026.05.1 -- https://docs.calitp.org/calitp.org/guides/dsdl/release/ -->
-    <link rel="stylesheet" href="https://6a0e339e78e8ea00086cacb6--cal-itp-website.netlify.app/stylesheets/dsdl/dsdl.css">
+    <link rel="stylesheet" href="https://www.calitp.org/stylesheets/dsdl/dsdl.css">
     <link rel="stylesheet" href="/styles/main.css">
     {% if stylesheet %}<link rel="stylesheet" href="/styles/{{ stylesheet }}">{% endif %}
 


### PR DESCRIPTION
This reverts commit c2f40b2594708895728339cac31a6a52ec5ae52f.

@Scotchester did some research of his own and learned that Netlify no longer keeps old deploys alive [forever](https://answers.netlify.com/t/does-each-deploy-preview-stay-available-forever/12601).

https://docs.netlify.com/deploy/manage-deploys/manage-deploys-overview/#automatic-deploy-deletion

for now lets just go back to loading the CSS directly from the `main` branch of https://github.com/cal-itp/calitp.org